### PR TITLE
fix: accessibilità e margini su back-button

### DIFF
--- a/projects/design-angular-kit/src/lib/components/navigation/back-button/back-button.component.html
+++ b/projects/design-angular-kit/src/lib/components/navigation/back-button/back-button.component.html
@@ -1,8 +1,8 @@
-<a href="#" *ngIf="buttonStyle === 'link'" (click)="goBack()">
+<a href="#" class="go-back" *ngIf="buttonStyle === 'link'" (click)="goBack()">
   <ng-container *ngTemplateOutlet="content"></ng-container>
 </a>
 
-<button *ngIf="buttonStyle === 'button'"
+<button class="go-back" *ngIf="buttonStyle === 'button'"
         itButton="primary"
         (click)="goBack()">
 

--- a/projects/design-angular-kit/src/lib/components/navigation/back-button/back-button.component.html
+++ b/projects/design-angular-kit/src/lib/components/navigation/back-button/back-button.component.html
@@ -1,11 +1,9 @@
-<a *ngIf="buttonStyle === 'link'" class="go-back" data-bs-toggle="historyback" (click)="goBack()" [routerLink]="null">
+<a href="#" *ngIf="buttonStyle === 'link'" (click)="goBack()">
   <ng-container *ngTemplateOutlet="content"></ng-container>
 </a>
 
 <button *ngIf="buttonStyle === 'button'"
         itButton="primary"
-        class="go-back"
-        data-bs-toggle="historyback"
         (click)="goBack()">
 
   <ng-container *ngTemplateOutlet="content"></ng-container>
@@ -16,7 +14,7 @@
            size="sm"
            [name]="direction === 'left' ? 'arrow-left' : 'arrow-up'"
            [color]="buttonStyle === 'link' ? 'primary' : 'white'"
-           [class.me-2]="isShowText"></it-icon>
+           [class]="isShowText ? 'me-2' : ''"></it-icon>
 
   <span [class.visually-hidden]="!isShowText">
     {{(direction === 'left' ? 'it.navigation.go-back' : 'it.navigation.upper-level') | translate}}

--- a/projects/design-angular-kit/src/lib/components/navigation/back-button/back-button.component.scss
+++ b/projects/design-angular-kit/src/lib/components/navigation/back-button/back-button.component.scss
@@ -1,3 +1,0 @@
-a.go-back {
-  cursor: pointer;
-}

--- a/projects/design-angular-kit/src/lib/components/navigation/back-button/back-button.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/navigation/back-button/back-button.component.spec.ts
@@ -81,4 +81,16 @@ describe('BackButtonComponent', () => {
     aElement.nativeElement.click();
     expect(component._location.back).toHaveBeenCalled();
   });
+
+  it('se passo una callback backFn, al click deve essere lanciata lei', () => {
+    component.backFn = () => {};
+    component.buttonStyle = 'link';
+    fixture.detectChanges();
+    spyOn(component, 'backFn');
+    const aElement = fixture.debugElement.query(By.css('a'));
+    aElement.nativeElement.removeAttribute("href");
+    fixture.detectChanges();
+    aElement.nativeElement.click();
+    expect(component.backFn).toHaveBeenCalled();
+  });
 });

--- a/projects/design-angular-kit/src/lib/components/navigation/back-button/back-button.component.ts
+++ b/projects/design-angular-kit/src/lib/components/navigation/back-button/back-button.component.ts
@@ -5,7 +5,6 @@ import { BooleanInput, isTrueBooleanInput } from '../../../utils/boolean-input';
 @Component({
   selector: 'it-back-button',
   templateUrl: './back-button.component.html',
-  styleUrls: ['./back-button.component.scss'],
   exportAs: 'itBackButton'
 })
 export class BackButtonComponent {


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
Fixati alcuni problemi e differenze grafiche con https://italia.github.io/bootstrap-italia/:

- tolta classe che dava cursor: pointer al tag anchor, rimosso routerLink null e aggiunto href="#", per rendere l'elemento **focusable**;
- rimosso il data attribute data-bs-toggle="historyback" che fungeva da selettore per la navigazione, in quanto ora è fatta **nativa** in angular;
- cambiato [class.me-2]="isShowText" (non funziona) in [class]="isShowText ? 'me-2' : ''", in quanto il componente it-icon ho visto prende in input class
- rimossa class="go-back" e .scss associato al componente (divenuto vuoto).

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x] Le modifiche sono conformi alle [linee guida di design](https://design-italia.readthedocs.io/it/stable/index.html).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://design-italia.readthedocs.io/it/stable/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.
