### PR TITLE
fix: make unique tabs id in source-display

### DIFF
--- a/src/app/shared/source-display/source-display.component.html
+++ b/src/app/shared/source-display/source-display.component.html
@@ -1,12 +1,12 @@
 <div class="source-display-container bd-example">
   <it-tab-container>
-    <it-tab-item id="html" *ngIf="html" label="HTML" active="true">
+    <it-tab-item [id]="uid + 'html'" *ngIf="html" label="HTML" active="true">
       <pre><code [highlight]="html"></code></pre>
     </it-tab-item>
-    <it-tab-item id="typescript" *ngIf="typescript" label="TypeScript" >
+    <it-tab-item [id]="uid + 'typescript'" *ngIf="typescript" label="TypeScript" >
       <pre><code [highlight]="typescript"></code></pre>
     </it-tab-item>
-    <it-tab-item id="scss" *ngIf="scss" label="SCSS">
+    <it-tab-item [id]="uid +'scss'" *ngIf="scss" label="SCSS">
       <pre><code [highlight]="scss"></code></pre>
     </it-tab-item>
   </it-tab-container>

--- a/src/app/shared/source-display/source-display.component.ts
+++ b/src/app/shared/source-display/source-display.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
 
+let nextUniqueId = 0;
 @Component({
   selector: 'it-source-display',
   templateUrl: './source-display.component.html',
@@ -10,6 +11,8 @@ export class SourceDisplayComponent implements OnInit {
   @Input() html: string;
   @Input() typescript: string;
   @Input() scss: string;
+
+  uid = `id-${nextUniqueId++}-`;
 
   ngOnInit() {
     if (this.html) {


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->
Questa PR fixa un comportamento anomale nel source-display (componente che mostra i tab html, typescript e SCSS nella docs). Quando si cliccava un altro tab (es: typescript), cambiava il primo, source-display e non quello con cui si stava interagendo. 
La fix genera un id univoco per i tab sotto quel componente.