### PR TITLE
fix(i18n): translations with lazy loading modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ npm install design-angular-kit@unstable --save
 Procedi a registrare `DesignAngularKitModule` nel tuo **app.module.ts**.
 
 ```typescript
-imports: [
+@NgModule({
+  imports: [
     ...
     DesignAngularKitModule
-]
+  ]
+})
 ```
 
 ### Importazione stili bootstrap-italia
@@ -144,11 +146,7 @@ Modifica il tuo `angular.json` aggiungendo:
   ]
  ```
 
-Puoi anche utilizzare le label localizzate di `design-angular-kit` nella tua applicazione. [Vedi le nostre label](projects/design-angular-kit/assets/i18n/it.json)
-
-Es: `{{'it.errors.required-field' | translate}}`
-
-#### Caricamento file localizzazione app 
+#### Localizzazione esistente
 
 Se utilizzi già i file di localizzazione nella tua app, puoi utilizzare la libreria [ngx-translate-multi-http-loader](https://www.npmjs.com/package/ngx-translate-multi-http-loader)
 per caricare i file di localizzazione dell'app e di `design-angular-kit`
@@ -156,29 +154,49 @@ per caricare i file di localizzazione dell'app e di `design-angular-kit`
 Modifica nel tuo `app.module.ts`:
 
 ```typescript
-imports: [
-  ...
-  HttpClientModule,
-  TranslateModule.forRoot({
-    loader: {
-      provide: TranslateLoader,
-      useFactory: (http: HttpBackend) => new MultiTranslateHttpLoader(http, [
-        './assets/i18n/', // Your i18n location
-        './bootstrap-italia/i18n/'
-      ]),
-      deps: [HttpBackend],
-      defaultLanguage: 'it'
-    }
-  }),
-  DesignAngularKitModule
-]
+@NgModule({
+  imports: [
+    ...
+    HttpClientModule,
+    TranslateModule.forRoot({
+      loader: {
+        provide: TranslateLoader,
+        useFactory: (http: HttpBackend) => new MultiTranslateHttpLoader(http, [
+          './bootstrap-italia/i18n/', // Load library translations first, so you can edit the keys in your localization file
+          './assets/i18n/', // Your i18n location
+        ]),
+        deps: [HttpBackend],
+        defaultLanguage: 'it'
+      }
+    }),
+    DesignAngularKitModule
+  ]
+})
 ```
 
-#### Usa la localizzazione personalizzata
+Se vuoi personalizzare le nostre label puoi aggiungere le localizzazioni nei tuoi file json, sovrascrivendo le [chiavi del json della libreria](projects/design-angular-kit/assets/i18n/it.json).
 
-Non includere il supporto i18n nel tuo `angular.json` ma crea i tuoi file di localizzazione personalizzata nella tua cartella `assets/bootstrap-italia/i18n/` (crea il percorso se non esiste). Il json deve avere [questo formato](projects/design-angular-kit/assets/i18n/it.json).
+Puoi utilizzare le label localizzate di `design-angular-kit` nella tua applicazione, ad esempio `{{'it.errors.required-field' | translate}}`. [Vedi le nostre label](projects/design-angular-kit/assets/i18n/it.json)
 
-Se utilizzi già i file di localizzazione nella tua app, puoi aggiungere le localizzazioni nei tuoi file json, sovrascrivendo le chiavi del json della libreria.
+#### Localizzazione non esistente
+
+Se non utilizzi i file di localizzazione nella tua app, devi aggiungere il provider `TranslateStore` nel tuo `app.module.ts`:
+
+```typescript
+@NgModule({
+  imports: [
+    ...
+    DesignAngularKitModule,
+  ],
+  providers: [
+    TranslateStore
+  ],
+})
+```
+
+Se vuoi personalizzare le nostre label:  
+- Non includere il supporto i18n nel tuo `angular.json` ma crea i tuoi file di localizzazione personalizzati nella tua cartella `assets/bootstrap-italia/i18n/` (crea il percorso se non esiste). 
+- Il json deve avere [questo formato](projects/design-angular-kit/assets/i18n/it.json).
 
 ### Supporto animazione
 

--- a/README.md
+++ b/README.md
@@ -163,11 +163,11 @@ Modifica nel tuo `app.module.ts`:
         provide: TranslateLoader,
         useFactory: (http: HttpBackend) => new MultiTranslateHttpLoader(http, [
           './bootstrap-italia/i18n/', // Load library translations first, so you can edit the keys in your localization file
-          './assets/i18n/', // Your i18n location
+          './assets/i18n/' // Your i18n location
         ]),
-        deps: [HttpBackend],
-        defaultLanguage: 'it'
-      }
+        deps: [HttpBackend]
+      },      
+      defaultLanguage: 'it'
     }),
     DesignAngularKitModule
   ]

--- a/projects/design-angular-kit/src/lib/design-angular-kit.module.ts
+++ b/projects/design-angular-kit/src/lib/design-angular-kit.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { TranslateLoader, TranslateModule, TranslateService, TranslateStore } from '@ngx-translate/core';
+import { TranslateLoader, TranslateModule, TranslateService } from '@ngx-translate/core';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { TranslateHttpLoader } from '@ngx-translate/http-loader';
 import { ComponentsModule } from './modules/components.module';
@@ -23,8 +23,7 @@ import { ComponentsModule } from './modules/components.module';
   exports: [
     ComponentsModule,
     TranslateModule
-  ],
-  providers: [TranslateStore]
+  ]
 })
 export class DesignAngularKitModule {
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from "@angular/platform-browser/animations";
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgModule } from '@angular/core';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -9,6 +9,7 @@ import { TableOfContentItemComponent } from './table-of-content-item/table-of-co
 import { RouterDispatcherComponent } from './router-dispatcher/router-dispatcher.component';
 import { LinkSortPipe } from './link-sort.pipe';
 import { HIGHLIGHT_OPTIONS } from 'ngx-highlightjs';
+import { TranslateStore } from '@ngx-translate/core';
 
 @NgModule({
   declarations: [
@@ -16,24 +17,28 @@ import { HIGHLIGHT_OPTIONS } from 'ngx-highlightjs';
     TableOfContentComponent,
     TableOfContentItemComponent,
     RouterDispatcherComponent,
-    LinkSortPipe,
+    LinkSortPipe
   ],
   imports: [
     BrowserModule,
     BrowserAnimationsModule,
     AppRoutingModule
   ],
-  providers: [{
-    provide: HIGHLIGHT_OPTIONS,
-    useValue: {
-      coreLibraryLoader: () => import('highlight.js/lib/core'),
-      languages: {
-        typescript: () => import('highlight.js/lib/languages/typescript'),
-        HTML: () => import('highlight.js/lib/languages/xml'),
-        scss: () => import('highlight.js/lib/languages/scss')
+  providers: [
+    TranslateStore,
+    {
+      provide: HIGHLIGHT_OPTIONS,
+      useValue: {
+        coreLibraryLoader: () => import('highlight.js/lib/core'),
+        languages: {
+          typescript: () => import('highlight.js/lib/languages/typescript'),
+          HTML: () => import('highlight.js/lib/languages/xml'),
+          scss: () => import('highlight.js/lib/languages/scss')
+        }
       }
     }
-  }],
+  ],
   bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {
+}


### PR DESCRIPTION
## Descrizione
Fixes: #193 

Rimosso il provider `TranslateStore` dalla libreria, aggiornato il README.md

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [ ] Le modifiche sono conformi alle [linee guida di design](https://design-italia.readthedocs.io/it/stable/index.html).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://design-italia.readthedocs.io/it/stable/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.

