### PR TITLE
feat: ability to filter autocomplete data on backend

### DIFF
--- a/projects/design-angular-kit/src/lib/components/form/input/input.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/input/input.component.html
@@ -85,7 +85,7 @@
             </div>
             <it-icon *ngIf="entry.icon" [name]="entry.icon" size="sm"></it-icon>
             <span class="autocomplete-list-text">
-            <span [innerHTML]="entry.original | markMatchingText: autocomplete.searchedValue"></span>
+            <span [innerHTML]="entry.value | markMatchingText: autocomplete.searchedValue"></span>
             <em *ngIf="entry.label">{{entry.label}}</em>
           </span>
           </ng-template>

--- a/projects/design-angular-kit/src/lib/components/form/input/input.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/input/input.component.html
@@ -64,43 +64,36 @@
 
   <small *ngIf="description" [id]="id + '-description'" class="form-text">{{description}}</small>
 
-
-
-
   <!-- INIZIO gestione AUTOCOMPLETAMENTO -->
+  <ng-container *ngIf="type === 'search'">
+    <!-- Icona lente per autocompletamento -->
+    <span class="autocomplete-icon" aria-hidden="true">
+      <it-icon name="search" size="sm"></it-icon>
+    </span>
 
-
-  <!-- Icona lente per autocompletamento -->
-  <span class="autocomplete-icon" aria-hidden="true" *ngIf="isAutocompletable()">
-    <it-icon name = "search" size="sm"></it-icon>
-  </span>
-
-  <ng-container *ngIf="autocompleteResults$ | async as autocomplete">
-    <!-- Lista di autocompletamento -->
-    <ul class="autocomplete-list" *ngIf="isAutocompletable()"  [class.autocomplete-list-show]="autocomplete.relatedEntries?.length && showAutocompletion">
-      <li *ngFor="let entry of autocomplete.relatedEntries; trackBy: autocompleteItemTrackByValueFn" (click)="onEntryClick(entry, $event)">
-        <a [href]="entry.link" >
-          <ng-container *ngTemplateOutlet="autocompleteItemTemplate"></ng-container>
-        </a>
-        <ng-template #autocompleteItemTemplate>
-          <div class="avatar size-sm" *ngIf="entry.avatarSrcPath">
-            <img [src]="entry.avatarSrcPath" [alt]="entry.avatarAltText">
-          </div>
-          <it-icon *ngIf="entry.icon" [name]="entry.icon" size="sm"></it-icon>
-          <span class="autocomplete-list-text">
-            <span [innerHTML] = "entry.original | markMatchingText: autocomplete.searchedValue"></span>
+    <ng-container *ngIf="autocompleteResults$ | async as autocomplete">
+      <!-- Lista di autocompletamento -->
+      <ul class="autocomplete-list" [class.autocomplete-list-show]="autocomplete.relatedEntries?.length && showAutocompletion">
+        <li *ngFor="let entry of autocomplete.relatedEntries; trackBy: autocompleteItemTrackByValueFn"
+            (click)="onEntryClick(entry, $event)">
+          <a [href]="entry.link">
+            <ng-container *ngTemplateOutlet="autocompleteItemTemplate"></ng-container>
+          </a>
+          <ng-template #autocompleteItemTemplate>
+            <div class="avatar size-sm" *ngIf="entry.avatarSrcPath">
+              <img [src]="entry.avatarSrcPath" [alt]="entry.avatarAltText">
+            </div>
+            <it-icon *ngIf="entry.icon" [name]="entry.icon" size="sm"></it-icon>
+            <span class="autocomplete-list-text">
+            <span [innerHTML]="entry.original | markMatchingText: autocomplete.searchedValue"></span>
             <em *ngIf="entry.label">{{entry.label}}</em>
           </span>
-        </ng-template>
-      </li>
-    </ul>
+          </ng-template>
+        </li>
+      </ul>
+    </ng-container>
   </ng-container>
-  
-
   <!-- FINE gestione AUTOCOMPLETAMENTO -->
-
-
-
 
   <div *ngIf="isInvalid" class="form-feedback just-validate-error-label" [id]="id + '-error'">
     <div #customError>

--- a/projects/design-angular-kit/src/lib/components/form/input/input.component.ts
+++ b/projects/design-angular-kit/src/lib/components/form/input/input.component.ts
@@ -152,7 +152,7 @@ export class InputComponent extends AbstractFormComponent<string | number> {
   }
 
   /** Observable da cui vengono emessi i risultati dell'auto completamento */
-  autocompleteResults$: Observable<{ searchedValue: string, relatedEntries: Array<AutocompleteItem & { original: string }> }> = new Observable();
+  autocompleteResults$: Observable<{ searchedValue: string, relatedEntries: Array<AutocompleteItem> }> = new Observable();
 
 
   override ngOnInit() {
@@ -211,7 +211,7 @@ export class InputComponent extends AbstractFormComponent<string | number> {
   /**
    * Create the autocomplete list
    */
-  private getAutocompleteResults$(): Observable<{ searchedValue: string, relatedEntries: Array<AutocompleteItem & { original: string }> }> {
+  private getAutocompleteResults$(): Observable<{ searchedValue: string, relatedEntries: Array<AutocompleteItem> }> {
     if (this.type !== 'search') {
       return of({ searchedValue: '', relatedEntries: [] });
     }
@@ -231,9 +231,7 @@ export class InputComponent extends AbstractFormComponent<string | number> {
             }
 
             const lowercaseValue = searchedValue.toLowerCase();
-            const relatedEntries = autocompleteData.filter(item => item.value?.toLowerCase().includes(lowercaseValue)).map(item => {
-              return { ...item, original: item.value } as (AutocompleteItem & { original: string });
-            });
+            const relatedEntries = autocompleteData.filter(item => item.value?.toLowerCase().includes(lowercaseValue));
 
             return { searchedValue, relatedEntries };
           })

--- a/projects/design-angular-kit/src/lib/components/form/input/input.component.ts
+++ b/projects/design-angular-kit/src/lib/components/form/input/input.component.ts
@@ -73,6 +73,13 @@ export class InputComponent extends AbstractFormComponent<string | number> {
   @Input() autocompleteData?: Array<AutocompleteItem> | ((search?: string) => Observable<Array<AutocompleteItem>>);
 
   /**
+   * Time span [ms] has passed without another source emission, to delay data filtering.
+   * Useful when the user is typing multiple letters
+   * @default 300 [ms]
+   */
+  @Input() autocompleteDebounceTime: number = 300;
+
+  /**
    * Fired when the Autocomplete Item has been selected
    */
   @Output() onAutocompleteSelected: EventEmitter<AutocompleteItem> = new EventEmitter();
@@ -216,7 +223,7 @@ export class InputComponent extends AbstractFormComponent<string | number> {
       return of({ searchedValue: '', relatedEntries: [] });
     }
     return this.control.valueChanges.pipe(
-      debounceTime(300), // After 300ms span has passed without another source emission, useful when the user is typing multiple letters
+      debounceTime(this.autocompleteDebounceTime), // Delay filter data after time span has passed without another source emission, useful when the user is typing multiple letters
       distinctUntilChanged(), // Only if searchValue is distinct in comparison to the last value
       switchMap(searchedValue => {
         if (!this.autocompleteData) {

--- a/projects/design-angular-kit/src/lib/components/form/input/input.component.ts
+++ b/projects/design-angular-kit/src/lib/components/form/input/input.component.ts
@@ -1,10 +1,10 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { AbstractFormComponent } from '../../../abstracts/abstract-form-component';
-import { AutoCompleteItem, InputControlType } from '../../../interfaces/form';
+import { AutocompleteItem, InputControlType } from '../../../interfaces/form';
 import { AbstractControl, ValidatorFn, Validators } from '@angular/forms';
 import { ItValidators } from '../../../validators/it-validators';
 import { BooleanInput, isTrueBooleanInput } from '../../../utils/boolean-input';
-import { map, Observable, of } from 'rxjs';
+import { debounceTime, distinctUntilChanged, map, Observable, of, switchMap } from 'rxjs';
 
 @Component({
   selector: 'it-input[id]',
@@ -66,14 +66,16 @@ export class InputComponent extends AbstractFormComponent<string | number> {
   @Input() adaptive?: BooleanInput;
 
   /**
-   * Opzionale.
-   * Disponibile solo se il type è search.
-   * Indica la lista di elementi ricercabili su cui basare il sistema di autocompletamento della input
+   * Indicates the list of searchable elements on which to base the input autocomplete system [Optional. Used only in type = 'search']
+   * If you need to retrieve items via API, can pass a function of Observable
+   * @default undefined
    */
-  @Input()
-  set autoCompleteData(value: Array<AutoCompleteItem>) { this._autoCompleteData = value; }
-  get autoCompleteData(): Array<AutoCompleteItem> { return this._autoCompleteData; }
-  private _autoCompleteData: Array<AutoCompleteItem> = [];
+  @Input() autocompleteData?: Array<AutocompleteItem> | ((search?: string) => Observable<Array<AutocompleteItem>>);
+
+  /**
+   * Fired when the Autocomplete Item has been selected
+   */
+  @Output() onAutocompleteSelected: EventEmitter<AutocompleteItem> = new EventEmitter();
 
   showAutocompletion = false;
 
@@ -150,7 +152,7 @@ export class InputComponent extends AbstractFormComponent<string | number> {
   }
 
   /** Observable da cui vengono emessi i risultati dell'auto completamento */
-  autocompleteResults$: Observable<{ searchedValue: string, relatedEntries: Array<AutoCompleteItem & { original: string, lowercase: string }>}> = new Observable();
+  autocompleteResults$: Observable<{ searchedValue: string, relatedEntries: Array<AutocompleteItem & { original: string }> }> = new Observable();
 
 
   override ngOnInit() {
@@ -206,56 +208,53 @@ export class InputComponent extends AbstractFormComponent<string | number> {
   }
 
 
-  
-  getAutocompleteResults$(): Observable<{ searchedValue: string, relatedEntries: Array<AutoCompleteItem & { original: string, lowercase: string }>}> {
-
-    if(this.type === 'search') {
-      return this.control.valueChanges.pipe(map((value) => {
-        const searchedValue = value;
-        if (searchedValue) {
-          const lowercaseValue = searchedValue.toLowerCase();
-          const lowercaseData = this._autoCompleteData.filter((item) => item.value).map(item => {
-            return { ...item, original : item.value, lowercase : item.value.toLowerCase() };
-          });
-    
-          const relatedEntries: Array<AutoCompleteItem & { original: string, lowercase: string }> = [];
-          lowercaseData.forEach(lowercaseEntry => {
-            const matching = (lowercaseEntry.lowercase).includes(lowercaseValue);
-            if (matching) {
-              relatedEntries.push(lowercaseEntry);
-            }
-          });
-  
-          return { searchedValue, relatedEntries };
-        } else {
-          return { searchedValue, relatedEntries: []};
+  /**
+   * Create the autocomplete list
+   */
+  private getAutocompleteResults$(): Observable<{ searchedValue: string, relatedEntries: Array<AutocompleteItem & { original: string }> }> {
+    if (this.type !== 'search') {
+      return of({ searchedValue: '', relatedEntries: [] });
+    }
+    return this.control.valueChanges.pipe(
+      debounceTime(300), // After 300ms span has passed without another source emission, useful when the user is typing multiple letters
+      distinctUntilChanged(), // Only if searchValue is distinct in comparison to the last value
+      switchMap(searchedValue => {
+        if (!this.autocompleteData) {
+          return of({ searchedValue, relatedEntries: [] });
         }
-      }));
-    } else {
-      return of({searchedValue: '', relatedEntries: []});
-    }
-    
+
+        const autoCompleteData$ = Array.isArray(this.autocompleteData) ? of(this.autocompleteData) : this.autocompleteData(searchedValue);
+        return autoCompleteData$.pipe(
+          map(autocompleteData => {
+            if (!searchedValue) {
+              return { searchedValue, relatedEntries: [] };
+            }
+
+            const lowercaseValue = searchedValue.toLowerCase();
+            const relatedEntries = autocompleteData.filter(item => item.value?.toLowerCase().includes(lowercaseValue)).map(item => {
+              return { ...item, original: item.value } as (AutocompleteItem & { original: string });
+            });
+
+            return { searchedValue, relatedEntries };
+          })
+        );
+      })
+    );
   }
 
-  isAutocompletable() {
-    if (this._autoCompleteData && this.type === 'search') {
-      return this._autoCompleteData.length > 0;
-    } else {
-      return false;
-    }
-  }
-
-  onEntryClick(entry: AutoCompleteItem, event: Event) {
-    // Se non è stato definito un link associato all'elemento dell'autocomplete, probabilmente il desiderata 
+  onEntryClick(entry: AutocompleteItem, event: Event) {
+    // Se non è stato definito un link associato all'elemento dell'autocomplete, probabilmente il desiderata
     // non è effettuare la navigazione al default '#', pertanto in tal caso meglio annullare la navigazione.
-    if(!entry.link) {
+    if (!entry.link) {
       event.preventDefault();
     }
+
+    this.onAutocompleteSelected.next(entry);
     this.control.setValue(entry.value);
     this.showAutocompletion = false;
   }
 
-  autocompleteItemTrackByValueFn(index: number, item: AutoCompleteItem) {
+  autocompleteItemTrackByValueFn(index: number, item: AutocompleteItem) {
     return item.value;
   }
 

--- a/projects/design-angular-kit/src/lib/interfaces/form.ts
+++ b/projects/design-angular-kit/src/lib/interfaces/form.ts
@@ -1,4 +1,4 @@
-import { IconName } from "./icon";
+import { IconName } from './icon';
 
 export type InputControlType = 'text' | 'email' | 'number' | 'date' | 'time' | 'tel' | 'color' | 'url' | 'search';
 
@@ -57,7 +57,7 @@ export interface UploadFileListItem {
 /**
  * Elemento disponibile per l'autocompletamento del it-form-input
  */
-export interface AutoCompleteItem {
+export interface AutocompleteItem {
   /** Valore voce di autocompletamento */
   value: string;
   /** Opzionale. Path in cui ricercare l'immagine dell'avatar da posizionare a sinistra della voce di autocompletamento */
@@ -69,5 +69,11 @@ export interface AutoCompleteItem {
   /** Opzionale. Label posizionata a destra della voce di autocompletamento */
   label?: string;
   /** Opzionale. Link relativo all'elemento */
-  link?: string
+  link?: string;
+
+  /**
+   * Attribute not used for autocomplete rendering.
+   * It can be useful to retrieve some extra information when selecting the autocomplete item
+   */
+  additionalData?: any;
 }

--- a/src/app/form-input/form-input-example/form-input-example.component.html
+++ b/src/app/form-input/form-input-example/form-input-example.component.html
@@ -12,7 +12,8 @@
                 [type]="type !== 'password' ? type : 'text'"
                 [(ngModel)]="value"
                 [description]="note"
-                [autocompleteData]="autoCompleteData">
+                [autocompleteData]="autocompleteUsers$"
+                (onAutocompleteSelected)="onAutocompleteSelected($event)">
       </it-input>
       <it-password-input *ngIf="type === 'password'" id="password-input-0"
                          [label]="label"

--- a/src/app/form-input/form-input-example/form-input-example.component.html
+++ b/src/app/form-input/form-input-example/form-input-example.component.html
@@ -12,7 +12,7 @@
                 [type]="type !== 'password' ? type : 'text'"
                 [(ngModel)]="value"
                 [description]="note"
-                [autoCompleteData]="autoCompleteData">
+                [autocompleteData]="autoCompleteData">
       </it-input>
       <it-password-input *ngIf="type === 'password'" id="password-input-0"
                          [label]="label"

--- a/src/app/form-input/form-input-example/form-input-example.component.ts
+++ b/src/app/form-input/form-input-example/form-input-example.component.ts
@@ -1,5 +1,6 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { AutocompleteItem, InputControlType } from 'projects/design-angular-kit/src/public_api';
+import { Observable, of } from 'rxjs';
 
 @Component({
   selector: 'it-form-input-example',
@@ -33,6 +34,9 @@ export class FormInputExampleComponent {
 
   hasNote = false;
 
+  /**
+   * Static AutocompleteData accepted by it-input
+   */
    get autoCompleteData(): AutocompleteItem[] {
      return this._autoCompleteData;
   }
@@ -71,4 +75,20 @@ export class FormInputExampleComponent {
      }
    ];
 
+  /**
+   * Dynamic AutocompleteData (API) accepted by it-input
+   * @param search the autocomplete input string
+   */
+  autocompleteUsers$ = (search?: string): Observable<Array<AutocompleteItem>> => {
+    if (!search) {
+      return of([]);
+    }
+
+    // API request for retrieve data, use `search` to filter data
+    return of(this._autoCompleteData);
+  }
+
+  onAutocompleteSelected(item: AutocompleteItem): void {
+    console.log(item);
+  }
 }

--- a/src/app/form-input/form-input-example/form-input-example.component.ts
+++ b/src/app/form-input/form-input-example/form-input-example.component.ts
@@ -1,5 +1,5 @@
 import { Component, ChangeDetectionStrategy } from '@angular/core';
-import { AutoCompleteItem, InputControlType } from 'projects/design-angular-kit/src/public_api';
+import { AutocompleteItem, InputControlType } from 'projects/design-angular-kit/src/public_api';
 
 @Component({
   selector: 'it-form-input-example',
@@ -33,13 +33,13 @@ export class FormInputExampleComponent {
 
   hasNote = false;
 
-   get autoCompleteData(): AutoCompleteItem[] {
+   get autoCompleteData(): AutocompleteItem[] {
      return this._autoCompleteData;
   }
-  set autoCompleteData(value: AutoCompleteItem[]) {
+  set autoCompleteData(value: AutocompleteItem[]) {
      this._autoCompleteData = value;
   }
-   private _autoCompleteData: AutoCompleteItem[] = [
+   private _autoCompleteData: AutocompleteItem[] = [
      {
        value: 'Luisa Neri',
        avatarSrcPath: 'https://randomuser.me/api/portraits/women/44.jpg',


### PR DESCRIPTION
## Descrizione
Aggiunta feature: #196 

Adesso:
- E' possible passare come `autocompleteData` anche una funzione che accetta come parametro il testo in input dell'autocomplete e restituisce un `Observable<Array<AutocompleteItem>>`
- Al click/selezione dell'elemento dell'autocomplete viene emesso come Output (`onAutocompleteSelected`) l'`AutocompleteItem` selezionato
- E' possibile aggiungere dei dati extra al `AutocompleteItem` in modo da essere recuperati alla selezione dell'elemento tramite `onAutocompleteSelected`

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [ ] Le modifiche sono conformi alle [linee guida di design](https://design-italia.readthedocs.io/it/stable/index.html).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://design-italia.readthedocs.io/it/stable/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C04H3C19D52)! -->
