### PR TITLE
feat: added ability to insert html label into checkbox and radiobutton

### DIFF
--- a/projects/design-angular-kit/src/lib/components/form/checkbox/checkbox.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/checkbox/checkbox.component.html
@@ -5,7 +5,7 @@
 
     <div *ngIf="toggle; else defaultStyle" class="toggles">
       <label [for]="id">
-        {{label}}
+        <ng-container *ngTemplateOutlet="htmlLabel"></ng-container>
         <input [id]="id"
                type="checkbox"
                [formControl]="control"
@@ -23,7 +23,9 @@
              [class.semi-checked]="isIndeterminate"
              [formControl]="control"
              [attr.aria-describedby]="id + '-help'">
-      <label class="form-check-label" [for]="id">{{label}}</label>
+      <label class="form-check-label" [for]="id">
+        <ng-container *ngTemplateOutlet="htmlLabel"></ng-container>
+      </label>
     </ng-template>
 
     <small *ngIf="isGroup" [id]="id + '-help'" class="form-text">
@@ -45,4 +47,11 @@
     <ng-content select="[error]"></ng-content>
   </div>
   <ng-container *ngIf="!customError.hasChildNodes()">{{invalidMessage | async}}</ng-container>
+</ng-template>
+
+<ng-template #htmlLabel>
+  <div #customLabel>
+    <ng-content select="[label]"></ng-content>
+  </div>
+  <ng-container *ngIf="!customLabel.hasChildNodes()">{{label}}</ng-container>
 </ng-template>

--- a/projects/design-angular-kit/src/lib/components/form/checkbox/checkbox.component.ts
+++ b/projects/design-angular-kit/src/lib/components/form/checkbox/checkbox.component.ts
@@ -1,11 +1,10 @@
-import {Component, Input} from '@angular/core';
-import {AbstractFormComponent} from "../../../abstracts/abstract-form-component";
-import {BooleanInput, isTrueBooleanInput} from "../../../utils/boolean-input";
+import { Component, Input } from '@angular/core';
+import { AbstractFormComponent } from '../../../abstracts/abstract-form-component';
+import { BooleanInput, isTrueBooleanInput } from '../../../utils/boolean-input';
 
 @Component({
-  selector: 'it-checkbox[id][label]',
-  templateUrl: './checkbox.component.html',
-  styleUrls: ['./checkbox.component.scss']
+  selector: 'it-checkbox[id]',
+  templateUrl: './checkbox.component.html'
 })
 export class CheckboxComponent extends AbstractFormComponent<boolean> {
 

--- a/projects/design-angular-kit/src/lib/components/form/radio-button/radio-button.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/radio-button/radio-button.component.html
@@ -14,21 +14,30 @@
       [formControl]="control"
       [attr.aria-describedby]="id + '-help'">
 
-    <label class="form-check-label" [for]="id">{{label}}</label>
+    <label class="form-check-label" [for]="id">
+      <div #customLabel>
+        <ng-content select="[label]"></ng-content>
+      </div>
+      <ng-container *ngIf="!customLabel.hasChildNodes()">{{label}}</ng-container>
+    </label>
 
     <small *ngIf="isGroup" [id]="id + '-help'" class="form-text">
       <ng-content></ng-content>
     </small>
 
     <div *ngIf="isInvalid && isGroup" class="form-feedback just-validate-error-label" [id]="id + '-error'">
-      <div #customError><ng-content select="[error]"></ng-content></div>
+      <div #customError>
+        <ng-content select="[error]"></ng-content>
+      </div>
       <ng-container *ngIf="!customError.hasChildNodes()">{{invalidMessage | async}}</ng-container>
     </div>
 
   </div>
 
   <div *ngIf="isInvalid && !isGroup" class="form-feedback just-validate-error-label" [id]="id + '-error'">
-    <div #customError><ng-content select="[error]"></ng-content></div>
+    <div #customError>
+      <ng-content select="[error]"></ng-content>
+    </div>
     <ng-container *ngIf="!customError.hasChildNodes()">{{invalidMessage | async}}</ng-container>
   </div>
 </ng-container>

--- a/projects/design-angular-kit/src/lib/components/form/radio-button/radio-button.component.ts
+++ b/projects/design-angular-kit/src/lib/components/form/radio-button/radio-button.component.ts
@@ -3,7 +3,7 @@ import { AbstractFormComponent } from '../../../abstracts/abstract-form-componen
 import { BooleanInput, isFalseBooleanInput, isTrueBooleanInput } from '../../../utils/boolean-input';
 
 @Component({
-  selector: 'it-radio-button[id][label][value]',
+  selector: 'it-radio-button[id][value]',
   templateUrl: './radio-button.component.html',
   styleUrls: ['./radio-button.component.scss']
 })

--- a/src/app/checkbox/checkbox-example-group/checkbox-example-group.component.html
+++ b/src/app/checkbox/checkbox-example-group/checkbox-example-group.component.html
@@ -8,7 +8,9 @@
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie libero.
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie liber
     </it-checkbox>
-    <it-checkbox id="third-checkbox" label="Terza checkbox raggruppata" group="true">
+    <it-checkbox id="third-checkbox" group="true">
+      <ng-container label> Terza <a href="https://italia.github.io/bootstrap-italia/docs/form/checkbox/">checkbox</a> raggruppata</ng-container>
+
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie libero.
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie libero.
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas molestie libero

--- a/src/app/checkbox/checkbox-example/checkbox-example.component.html
+++ b/src/app/checkbox/checkbox-example/checkbox-example.component.html
@@ -5,17 +5,27 @@
     <it-checkbox id="spuntato" [(ngModel)]="checked" label="Spuntato"></it-checkbox>
     <it-checkbox id="disabilitato" [(ngModel)]="disabled" label="Disabilitato"></it-checkbox>
     <it-checkbox id="indeterminato" [(ngModel)]="indeterminate" label="Indeterminato"></it-checkbox>
+    <it-checkbox id="link" [(ngModel)]="link" label="Testo con link"></it-checkbox>
   </p>
 
   <h4>Risultato</h4>
 
   <p class="example-section">
-      <it-checkbox
-          id="example"
-          [(ngModel)]="checked"
-          [label]="label"
-          [indeterminate]="indeterminate"
-          [disabled]="disabled"></it-checkbox>
+    <it-checkbox
+      id="example"
+      [(ngModel)]="checked"
+      [indeterminate]="indeterminate"
+      [disabled]="disabled">
+
+      <ng-container label>
+        <ng-container *ngIf="link; else simpleLabel">
+          Accetto i <a href="https://italia.github.io/bootstrap-italia/">termini di servizio</a>
+        </ng-container>
+        <ng-template #simpleLabel>
+          Sono una checkbox
+        </ng-template>
+      </ng-container>
+    </it-checkbox>
   </p>
 
 </div>

--- a/src/app/checkbox/checkbox-example/checkbox-example.component.ts
+++ b/src/app/checkbox/checkbox-example/checkbox-example.component.ts
@@ -8,8 +8,8 @@ import { Component } from '@angular/core';
 export class CheckboxExampleComponent {
 
   checked = true;
-  label = 'Sono una checkbox';
   disabled = false;
   indeterminate = false;
+  link = false;
 
 }

--- a/src/app/radio/radio-example/radio-example.component.html
+++ b/src/app/radio/radio-example/radio-example.component.html
@@ -16,6 +16,17 @@
   </div>
 </div>
 
+<div class="bd-example">
+  <h4>Radio con link</h4>
+  <it-radio-button id="radio-link-it" [(ngModel)]="link" name="radio-link" value="bootstrap-italia">
+    <ng-container label>Label con <a href="https://italia.github.io/bootstrap-italia/">link</a></ng-container>
+  </it-radio-button>
+  <it-radio-button id="radio-link-rb" [(ngModel)]="link" name="radio-link" value="radio-button">
+    <ng-container label>Altra label con <a href="https://italia.github.io/bootstrap-italia/docs/form/radio-button/">link</a></ng-container>
+  </it-radio-button>
+
+  <div class="example-selected-value">Link selezionato: <strong>{{link}}</strong></div>
+</div>
 
 <div class="bd-example">
   <h4>Radio in Reactive Form</h4>

--- a/src/app/radio/radio-example/radio-example.component.ts
+++ b/src/app/radio/radio-example/radio-example.component.ts
@@ -18,6 +18,7 @@ export class RadioExampleComponent implements OnInit {
 
   disabled = false;
 
+  link?: string;
 
   genderFormGroup: FormGroup;
 


### PR DESCRIPTION
## Descrizione
Aggiunta la possibilità di inserire html nelle label dei Checkbox/Toggle e RadioButton  #198 

Esempio
```html
<!--Testo semplice-->
<it-checkbox id="example-text" label="Testo"></it-checkbox>

<!--Con Html-->
<it-checkbox  id="example-html">
        <ng-container label>
            Accetto i <a href="https://italia.github.io/bootstrap-italia/">termini di servizio</a>
        </ng-container>
</it-checkbox>
```

nel caso di inserimento di selettore + attributo, prevale il selettore:

```html
<!--Viene mostrato il testo con link-->
<it-checkbox  id="example-html-text" label="Testo">
        <ng-container label>
            Accetto i <a href="https://italia.github.io/bootstrap-italia/">termini di servizio</a>
        </ng-container>
</it-checkbox>
```

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [ ] Le modifiche sono conformi alle [linee guida di design](https://design-italia.readthedocs.io/it/stable/index.html).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://design-italia.readthedocs.io/it/stable/doc/service-design/accessibilita.html).
- [x] La documentazione è stata aggiornata.
