### PR TITLE
Remove unnecessary element from dropdown button when is <a>

### DIFF
--- a/projects/design-angular-kit/src/lib/components/core/dropdown/dropdown/dropdown.component.html
+++ b/projects/design-angular-kit/src/lib/components/core/dropdown/dropdown/dropdown.component.html
@@ -14,13 +14,13 @@
   <ng-template #linkButton>
     <a #dropdownButton
        [id]="id"
-       class="btn btn-dropdown dropdown-toggle"
+       class="dropdown-toggle nav-link"
        role="button"
        data-bs-toggle="dropdown"
        aria-haspopup="true"
        aria-expanded="false">
       <ng-container *ngTemplateOutlet="buttonContent"></ng-container>
-      <it-icon svgClass="icon-expand" name="expand" size="sm" color="primary"></it-icon>
+      <it-icon svgClass="icon-expand" name="expand" size="sm"></it-icon>
     </a>
   </ng-template>
 


### PR DESCRIPTION
## Descrizione
- Remove unnecessary class (btn btn-dropdown) from dropdown button when is <a> and add class (nav-link) for work in the header.
- Remove unnecessary attribute (color="primary") from icon of dropdown button when is <a>

## Checklist
- [X] Le modifiche sono conformi alle [linee guida di design](https://design-italia.readthedocs.io/it/stable/index.html).
- [x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [X] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [X] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://design-italia.readthedocs.io/it/stable/doc/service-design/accessibilita.html).
- [X] La documentazione è stata aggiornata.