### PR TITLE
fix: a11y aggiunta labelWaria sui componenti Callout,  Autocomplete e Stepper

### DIFF
--- a/projects/design-angular-kit/src/lib/components/core/callout/callout.component.html
+++ b/projects/design-angular-kit/src/lib/components/core/callout/callout.component.html
@@ -11,7 +11,7 @@
 <ng-template #inner>
   @if (label) {
     <div class="callout-title">
-      <it-icon [name]="iconName"></it-icon>
+      <it-icon [labelWaria]="labelWaria" [name]="iconName"></it-icon>
       @if (hiddenLabel) {
         <span class="visually-hidden">{{ hiddenLabel }}</span>
       }

--- a/projects/design-angular-kit/src/lib/components/core/callout/callout.component.ts
+++ b/projects/design-angular-kit/src/lib/components/core/callout/callout.component.ts
@@ -61,6 +61,16 @@ export class ItCalloutComponent {
    */
   @Input() icon: IconName | undefined;
 
+  /**
+   *  The input label even get labelWaria icon
+   * @default undefined
+   */
+  @Input() labelWaria: string | undefined = undefined;
+
+  getlabel() {
+    return this.labelWaria;
+  }
+
   protected get iconName(): IconName {
     if (this.icon) {
       return this.icon;

--- a/projects/design-angular-kit/src/lib/components/core/steppers/steppers-container/steppers-container.component.html
+++ b/projects/design-angular-kit/src/lib/components/core/steppers/steppers-container/steppers-container.component.html
@@ -6,7 +6,7 @@
           @for (step of steps; track step.id; let i = $index) {
             <li [class.confirmed]="i < activeStep" [class.active]="i === activeStep" [class.no-line]="i === activeStep && steppersNumber">
               @if (step.icon && !steppersNumber) {
-                <it-icon [name]="step.icon"></it-icon>
+                <it-icon [labelWaria]="'check'" [name]="step.icon"></it-icon>
               }
               @if (steppersNumber) {
                 <span class="steppers-number">
@@ -58,7 +58,7 @@
           class="steppers-btn-prev"
           [disabled]="disableBackButton"
           (click)="backClick.emit(activeStep)">
-          <it-icon name="chevron-left" color="primary"></it-icon>
+          <it-icon [labelWaria]="'left'" name="chevron-left" color="primary"></it-icon>
           {{ 'it.core.back' | translate }}
         </button>
       }
@@ -101,7 +101,7 @@
           [disabled]="disableForwardButton"
           (click)="forwardClick.emit(activeStep)">
           {{ 'it.core.forward' | translate }}
-          <it-icon name="chevron-right" color="primary"></it-icon>
+          <it-icon [labelWaria]="'right'" name="chevron-right" color="primary"></it-icon>
         </button>
       }
       @if (showConfirmButton) {
@@ -121,6 +121,6 @@
 </div>
 
 <ng-template #checkIcon>
-  <it-icon name="check" class="steppers-success"></it-icon>
+  <it-icon [labelWaria]="'check'" name="check" class="steppers-success"></it-icon>
   <span class="visually-hidden">{{ 'it.core.confirmed' | translate }}</span>
 </ng-template>

--- a/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.html
@@ -17,7 +17,7 @@
     (keydown)="onKeyDown()" />
 
   <span class="autocomplete-icon" aria-hidden="true">
-    <it-icon name="search" size="sm"></it-icon>
+    <it-icon [labelWaria]="labelWaria" name="search" size="sm"></it-icon>
   </span>
 
   @if (autocompleteResults$ | async; as autocomplete) {

--- a/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.ts
+++ b/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.ts
@@ -41,6 +41,11 @@ export class ItAutocompleteComponent extends ItAbstractFormComponent<string | nu
   @Input() placeholder = '';
 
   /**
+   * The input label even get labelWaria icon
+   */
+  @Input() labelWaria: string | undefined = undefined;
+
+  /**
    * Show the label
    */
   @Input({ transform: inputToBoolean }) forceShowLabel: boolean = true;


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->
fix: a11y Aggiunta labelWaria sui componenti Callout,  Autocomplete e Stepper

## Descrizione
<!--- Descrivi le modifiche in dettaglio -->
<!--- Se necessario, aggiungi "Fixes #XX" per chiudere automaticamente la issue indicata in caso di approvazione. -->

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [ ] Le modifiche sono conformi alle [linee guida di design](https://design-italia.readthedocs.io/it/stable/index.html).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://design-italia.readthedocs.io/it/stable/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C04H3C19D52)! -->
