### PR TITLE
fix: used fill-opacity along with opacity to display the sorting arro…

### DIFF
--- a/projects/design-angular-kit/src/lib/components/core/table/sort/sort-header/sort-header.component.scss
+++ b/projects/design-angular-kit/src/lib/components/core/table/sort/sort-header/sort-header.component.scss
@@ -14,6 +14,7 @@
 
     .it-sort-arrow {
       opacity: 0 !important;
+      fill-opacity: 0 !important;
     }
   }
 
@@ -33,23 +34,32 @@
 
   .it-sort-arrow {
     opacity: 0;
-    transition: opacity .3s ease-out;
-    -moz-transition: opacity .3s ease-out;
-    -webkit-transition: opacity .3s ease-out;
-    -o-transition: opacity .3s ease-out;
+    fill-opacity: 0;
+    transition:
+      fill-opacity 0.3s ease-out,
+      opacity 0.3s ease-out;
+    -moz-transition:
+      fill-opacity 0.3s ease-out,
+      opacity 0.3s ease-out;
+    -webkit-transition:
+      fill-opacity 0.3s ease-out,
+      opacity 0.3s ease-out;
+    -o-transition:
+      fill-opacity 0.3s ease-out,
+      opacity 0.3s ease-out;
   }
 
   &:hover {
     .it-sort-arrow {
       opacity: 0.5;
+      fill-opacity: 0.5;
     }
   }
 
   &.it-sort-header-sorted {
     .it-sort-arrow {
       opacity: 1 !important;
+      fill-opacity: 1 !important;
     }
   }
 }
-
-


### PR DESCRIPTION
Modificata la classe di visualizzazione delle frecce di ordinamento delle tabelle

## Descrizione
Insieme all'attributo opacity è stato utilizzato fill-opacity per permettere la corretta visualizzazione delle frecce di ordinamento con browser recenti

fixed:  italia/design-angular-kit#323

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [x ] Le modifiche sono conformi alle [linee guida di design](https://design-italia.readthedocs.io/it/stable/index.html).
- [ x] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [x ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://design-italia.readthedocs.io/it/stable/doc/service-design/accessibilita.html).
- [ x] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C04H3C19D52)! -->
