### PR TITLE
feat: slimTitleLink

### DIFF
--- a/projects/design-angular-kit/src/lib/components/navigation/header/header.component.html
+++ b/projects/design-angular-kit/src/lib/components/navigation/header/header.component.html
@@ -10,7 +10,9 @@
         <div class="row">
           <div class="col-12">
             <div class="it-header-slim-wrapper-content">
-              <a class="d-none d-lg-block navbar-brand" href="#">{{ slimTitle }}</a>
+              <a class="d-none d-lg-block navbar-brand" [href]="slimTitleLink" [target]="slimTitleLink !== '#' ? '_blank' : '_self'">
+                {{ slimTitle }}
+              </a>
               <div class="nav-mobile">
                 <nav [attr.aria-label]="'it.navigation.secondary-navigation' | translate">
                   <a

--- a/projects/design-angular-kit/src/lib/components/navigation/header/header.component.ts
+++ b/projects/design-angular-kit/src/lib/components/navigation/header/header.component.ts
@@ -38,6 +38,7 @@ export class ItHeaderComponent implements AfterViewInit, OnChanges {
   @Input({ transform: inputToBoolean }) showSearch?: boolean = true;
 
   @Input() slimTitle: string | undefined;
+  @Input() slimTitleLink: string | undefined = '#';
 
   @Input() loginStyle: 'none' | 'default' | 'full' = 'none';
 

--- a/src/app/header/header-example/header-example.component.html
+++ b/src/app/header/header-example/header-example.component.html
@@ -2,6 +2,7 @@
 <div class="bd-example">
   <it-header
     slimTitle="Ente di appartenenza"
+    slimTitleLink="https://italia.github.io/design-angular-kit"
     [loginStyle]="login"
     [light]="light"
     [showSearch]="search"


### PR DESCRIPTION
Aggiunta proprietà  link relativa a slimTitle in ItHeaderComponent (visualizzazione desktop)

## Descrizione
Nel componte ItHeader è presente la possibilità di indicare la proprietà slimTitle, ma il link associato è sempre indicato con il valore '#'.
Aggiunta proprietà, con default '#', per aggiungere slimTitleLink associato all'etichetta. Il target del link è stato impostato a '_blank' se il contenuto è diverso da '#'.

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [ ] Le modifiche sono conformi alle [linee guida di design](https://design-italia.readthedocs.io/it/stable/index.html).
- [ ] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [x] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://design-italia.readthedocs.io/it/stable/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C04H3C19D52)! -->
