### PR TITLE
fix(docs): add missing radio button label in badge example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ Thumbs.db
 # Generated files
 /**/*-examples.component.html
 /src/assets/documentation.json
+
+# Nx
+.nx

--- a/src/app/badge/badge-example/badge-example.component.html
+++ b/src/app/badge/badge-example/badge-example.component.html
@@ -16,6 +16,7 @@
                 name="color"
                 [span]="color"
                 [value]="color"
+                [label]="color"
                 [(ngModel)]="selectedColor"></it-radio-button>
             </ng-container>
           </div>


### PR DESCRIPTION
<!--- IMPORTANTE: Rivedi [come contribuire](../CONTRIBUTING.md) nel caso tu non l'abbia già fatto. -->
<!--- Inserisci una sintesi delle modifiche nel titolo qui sopra -->

## Descrizione
The radio button in the badge example, that lets you choose the badge color, is missing the labels.
Moreover, the .nx directory has been added in the .gitignore file.

## Checklist
<!--- Controlla i punti seguenti, e inserisci una `x` nei campi d'interesse. -->
- [X] Le modifiche sono conformi alle [linee guida di design](https://design-italia.readthedocs.io/it/stable/index.html).
- [X] Il codice è coerente con le [indicazioni di progetto](https://italia.github.io/bootstrap-italia/docs/come-iniziare/).
- [ ] Le modifiche sono state verificate sui [Browser supportati](https://getbootstrap.com/docs/4.0/getting-started/browsers-devices/) e per diverse risoluzioni dello schermo.
- [ ] Sono stati effettuati test di accessibilità in ottemperanza a quanto descritto nell'[area "Accessibilità" delle linee guida di design](https://design-italia.readthedocs.io/it/stable/doc/service-design/accessibilita.html).
- [ ] La documentazione è stata aggiornata.

<!-- Se qualcosa non è chiaro, contattaci sullo Slack di Developers Italia (https://developersitalia.slack.com/messages/C04H3C19D52)! -->

Before:
![image](https://github.com/italia/design-angular-kit/assets/1497044/c6504605-f2ab-43a6-b9a2-b97af269be7f)

After:
![image](https://github.com/italia/design-angular-kit/assets/1497044/09d0018e-4a97-463c-9e51-c9f77cf29e70)
