### PR TITLE
fix(a11y): make aria-describedby conditional across all form components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 
 # Nx
 .nx
+.proof/

--- a/projects/design-angular-kit/src/lib/components/form/checkbox/checkbox.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/checkbox/checkbox.component.html
@@ -8,7 +8,7 @@
             [id]="id"
             type="checkbox"
             [formControl]="control"
-            [attr.aria-describedby]="id + '-help'"
+            [attr.aria-describedby]="group ? id + '-help' : null"
             (click)="$event.stopPropagation()" />
           <span class="lever"></span>
         </label>

--- a/projects/design-angular-kit/src/lib/components/form/checkbox/checkbox.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/form/checkbox/checkbox.component.spec.ts
@@ -18,4 +18,28 @@ describe('ItCheckboxComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should NOT render aria-describedby on toggle checkbox when group is false', () => {
+    component.toggle = true;
+    component.group = false;
+    fixture.detectChanges();
+    const inputEl = (fixture.nativeElement as HTMLElement).querySelector('input[type="checkbox"]');
+    expect(inputEl?.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('should render aria-describedby on toggle checkbox when group is true', () => {
+    fixture.componentRef.setInput('toggle', true);
+    fixture.componentRef.setInput('group', true);
+    fixture.detectChanges();
+    const inputEl = (fixture.nativeElement as HTMLElement).querySelector('input[type="checkbox"]');
+    expect(inputEl?.getAttribute('aria-describedby')).toBe(`${component.id}-help`);
+  });
+
+  it('should NOT render aria-describedby on standard checkbox when group is false', () => {
+    component.toggle = false;
+    component.group = false;
+    fixture.detectChanges();
+    const inputEl = (fixture.nativeElement as HTMLElement).querySelector('input[type="checkbox"]');
+    expect(inputEl?.getAttribute('aria-describedby')).toBeNull();
+  });
 });

--- a/projects/design-angular-kit/src/lib/components/form/input/input.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/input/input.component.html
@@ -38,7 +38,7 @@
         [placeholder]="placeholder"
         [readonly]="isReadonly"
         [autocomplete]="autocomplete"
-        [attr.aria-describedby]="id + '-description'"
+        [attr.aria-describedby]="description ? id + '-description' : null"
         (blur)="markAsTouched()" />
       <span class="input-group-text align-buttons flex-column">
         <button type="button" class="input-number-add" [disabled]="!control.enabled" (click)="incrementNumber()">
@@ -62,7 +62,7 @@
         [placeholder]="placeholder"
         [readonly]="isReadonly"
         [autocomplete]="autocomplete"
-        [attr.aria-describedby]="id + '-description'"
+        [attr.aria-describedby]="description ? id + '-description' : null"
         (blur)="markAsTouched()" />
     }
 

--- a/projects/design-angular-kit/src/lib/components/form/input/input.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/form/input/input.component.spec.ts
@@ -18,4 +18,33 @@ describe('ItInputComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should NOT render aria-describedby when description is not provided', () => {
+    component.description = undefined;
+    fixture.detectChanges();
+    const inputEl = (fixture.nativeElement as HTMLElement).querySelector('input');
+    expect(inputEl?.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('should render aria-describedby pointing to description element when description is provided', () => {
+    fixture.componentRef.setInput('description', 'Helper text for input');
+    fixture.detectChanges();
+    const inputEl = (fixture.nativeElement as HTMLElement).querySelector('input');
+    const descEl = (fixture.nativeElement as HTMLElement).querySelector(`#${component.id}-description`);
+    expect(inputEl?.getAttribute('aria-describedby')).toBe(`${component.id}-description`);
+    expect(descEl).toBeTruthy();
+    expect(descEl?.textContent?.trim()).toBe('Helper text for input');
+  });
+
+  it('should render aria-describedby on number input only when description is provided', () => {
+    fixture.componentRef.setInput('type', 'number');
+    fixture.componentRef.setInput('description', undefined);
+    fixture.detectChanges();
+    const inputEl = (fixture.nativeElement as HTMLElement).querySelector('input[type="number"]');
+    expect(inputEl?.getAttribute('aria-describedby')).toBeNull();
+
+    fixture.componentRef.setInput('description', 'Number helper');
+    fixture.detectChanges();
+    expect(inputEl?.getAttribute('aria-describedby')).toBe(`${component.id}-description`);
+  });
 });

--- a/projects/design-angular-kit/src/lib/components/form/password-input/password-input.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/password-input/password-input.component.html
@@ -11,7 +11,7 @@
     [class.is-valid]="isValid"
     [formControl]="control"
     [placeholder]="placeholder"
-    [attr.aria-describedby]="id + '-description'"
+    [attr.aria-describedby]="description !== undefined || isStrengthMeter ? id + '-description' : null"
     [autocomplete]="confirmPasswordField ? 'off' : autocomplete" />
 
   <span class="password-icon" aria-hidden="true">

--- a/projects/design-angular-kit/src/lib/components/form/password-input/password-input.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/form/password-input/password-input.component.spec.ts
@@ -18,4 +18,18 @@ describe('ItPasswordInputComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should NOT render aria-describedby when description is undefined', () => {
+    component.description = undefined;
+    fixture.detectChanges();
+    const inputEl = (fixture.nativeElement as HTMLElement).querySelector('input[type="password"]');
+    expect(inputEl?.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('should render aria-describedby when description is provided', () => {
+    fixture.componentRef.setInput('description', 'Password requirements');
+    fixture.detectChanges();
+    const inputEl = (fixture.nativeElement as HTMLElement).querySelector('input[type="password"]');
+    expect(inputEl?.getAttribute('aria-describedby')).toBe(`${component.id}-description`);
+  });
 });

--- a/projects/design-angular-kit/src/lib/components/form/radio-button/radio-button.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/radio-button/radio-button.component.html
@@ -8,7 +8,7 @@
       [class.is-invalid]="isInvalid"
       [class.is-valid]="isValid"
       [formControl]="control"
-      [attr.aria-describedby]="id + '-help'" />
+      [attr.aria-describedby]="group ? id + '-help' : null" />
 
     <label class="form-check-label" [for]="id">
       <div #customLabel>

--- a/projects/design-angular-kit/src/lib/components/form/radio-button/radio-button.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/form/radio-button/radio-button.component.spec.ts
@@ -18,4 +18,18 @@ describe('ItRadioButtonComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should NOT render aria-describedby when group is false', () => {
+    component.group = false;
+    fixture.detectChanges();
+    const inputEl = (fixture.nativeElement as HTMLElement).querySelector('input[type="radio"]');
+    expect(inputEl?.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('should render aria-describedby when group is true', () => {
+    fixture.componentRef.setInput('group', true);
+    fixture.detectChanges();
+    const inputEl = (fixture.nativeElement as HTMLElement).querySelector('input[type="radio"]');
+    expect(inputEl?.getAttribute('aria-describedby')).toBe(`${component.id}-help`);
+  });
 });

--- a/projects/design-angular-kit/src/lib/components/form/select/select.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/select/select.component.html
@@ -8,7 +8,7 @@
     [class.is-invalid]="isInvalid"
     [class.is-valid]="isValid"
     (blur)="markAsTouched()"
-    [attr.aria-describedby]="id + '-description'">
+    [attr.aria-describedby]="description ? id + '-description' : null">
     @if (defaultOption) {
       <option [ngValue]="null" disabled selected>
         {{ defaultOption }}

--- a/projects/design-angular-kit/src/lib/components/form/select/select.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/form/select/select.component.spec.ts
@@ -19,4 +19,21 @@ describe('ItSelectComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should NOT render aria-describedby when description is not provided', () => {
+    component.description = undefined;
+    fixture.detectChanges();
+    const selectEl = (fixture.nativeElement as HTMLElement).querySelector('select');
+    expect(selectEl?.getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('should render aria-describedby when description is provided', () => {
+    fixture.componentRef.setInput('description', 'Select a value');
+    fixture.detectChanges();
+    const selectEl = (fixture.nativeElement as HTMLElement).querySelector('select');
+    const descEl = (fixture.nativeElement as HTMLElement).querySelector(`#${component.id}-description`);
+    expect(selectEl?.getAttribute('aria-describedby')).toBe(`${component.id}-description`);
+    expect(descEl).toBeTruthy();
+    expect(descEl?.textContent?.trim()).toBe('Select a value');
+  });
 });


### PR DESCRIPTION
## Closes #561

### Problem

All form components (`it-input`, `it-select`, `it-radio-button`, `it-checkbox` toggle variant, `it-password-input`) unconditionally render `aria-describedby` pointing to `<id>-description` or `<id>-help`, even when no description or help text is provided. This creates a broken ARIA reference that screen readers may report as an error.

### Root cause

The `aria-describedby` attribute was hardcoded in each template without a conditional check for the presence of the associated description/help element.

### Fix

Changed all affected templates to use conditional attribute binding:

```html
<!-- Before -->
[attr.aria-describedby]="id + '-description'"

<!-- After -->
[attr.aria-describedby]="description ? id + '-description' : null"
```

When no description is provided, the attribute is removed entirely (Angular renders `null` as attribute removal).

### Affected components

| Component | Condition | Suffix |
|-----------|-----------|--------|
| `it-input` (text + number) | `description` | `-description` |
| `it-select` | `description` | `-description` |
| `it-radio-button` | `group` | `-help` |
| `it-checkbox` (toggle) | `group` | `-help` |
| `it-password-input` | `description \|\| isStrengthMeter` | `-description` |

### Tests

Added 12 new regression tests across all 5 spec files:
- **Negative cases** (no description → no `aria-describedby`): all pass ✅
- **Positive cases** (description provided → correct `aria-describedby`): all pass ✅
- Uses `fixture.componentRef.setInput()` to properly trigger OnPush change detection

### Verification

Full test suite: **121/121 SUCCESS**, zero regressions.
Lint: **0 errors**, 8 pre-existing warnings (unchanged).