### PR TITLE
fix(a11y): autocomplete listbox aria-labelledby references label instead of input

### DIFF
--- a/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.html
@@ -1,6 +1,6 @@
 <div class="form-group">
   @if (label) {
-    <label [for]="id" [class.active]="!!control.value">{{ label }}</label>
+    <label [for]="id" [id]="id + '-label'" [class.active]="!!control.value">{{ label }}</label>
   }
   <div #selectAutocomplete name="region" [id]="id + 'Wrapper'" class="autocomplete-wrapper"></div>
 

--- a/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.spec.ts
@@ -18,4 +18,20 @@ describe('ItAutocompleteComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should render label with id matching id-label pattern when label is provided', () => {
+    fixture.componentRef.setInput('label', 'Categoria');
+    fixture.detectChanges();
+    const labelEl = (fixture.nativeElement as HTMLElement).querySelector('label');
+    expect(labelEl).toBeTruthy();
+    expect(labelEl?.id).toBe(`${component.id}-label`);
+    expect(labelEl?.textContent?.trim()).toBe('Categoria');
+  });
+
+  it('should NOT render label element when label is not provided', () => {
+    fixture.componentRef.setInput('label', undefined);
+    fixture.detectChanges();
+    const labelEl = (fixture.nativeElement as HTMLElement).querySelector('label');
+    expect(labelEl).toBeNull();
+  });
 });

--- a/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.ts
+++ b/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.ts
@@ -148,6 +148,13 @@ export class ItAutocompleteComponent extends ItAbstractFormComponent<string | nu
         this.markAsTouched();
         this._setAndCheck((ev.target as HTMLInputElement).value);
       };
+
+      // Fix aria-labelledby: bootstrap-italia sets it to the input's id,
+      // but it should point to the label element for proper accessible naming
+      if (this.label) {
+        const listbox = this.selectAutocompleteEl?.nativeElement.querySelector('ul[role="listbox"]');
+        listbox?.setAttribute('aria-labelledby', this.id + '-label');
+      }
     }
   }
 


### PR DESCRIPTION
## Closes #551

### Problem

`it-autocomplete` generates a `<ul role="listbox">` via `SelectAutocomplete` (bootstrap-italia) with `aria-labelledby` pointing to the `<input>` element's ID. Since the input itself has no visible text content, screen readers cannot derive a meaningful accessible name for the listbox. Additionally, the `<label>` element lacks its own `id`, making it impossible to reference.

### Fix

1. **Template**: Added `[id]="id + '-label'"` to the `<label>` element so it has a referenceable ID
2. **Component**: After `SelectAutocomplete` DOM initialization, the generated `ul[role="listbox"]`'s `aria-labelledby` is corrected to point to the label's ID instead of the input's ID

### Before / After

```html
<!-- Before -->
<label for="autocomplete-1">Categoria</label>
<ul role="listbox" aria-labelledby="autocomplete-1"> <!-- points to input -->

<!-- After -->
<label for="autocomplete-1" id="autocomplete-1-label">Categoria</label>
<ul role="listbox" aria-labelledby="autocomplete-1-label"> <!-- points to label -->
```

### Tests

Added 2 regression tests:
- Label renders with correct `id` pattern (`id + '-label'`) when `label` input is provided ✅
- Label element is absent when `label` input is not provided ✅

Full test suite: **111/111 SUCCESS**, zero regressions.
Lint: **0 errors**, 8 pre-existing warnings.