### PR TITLE
fix(pagination): add display:block to host element

### DIFF
--- a/projects/design-angular-kit/src/lib/components/core/pagination/pagination.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/core/pagination/pagination.component.spec.ts
@@ -18,4 +18,10 @@ describe('ItPaginationComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should render host as display:block to allow margin utilities (#570, #571)', () => {
+    const host = fixture.nativeElement as HTMLElement;
+    const computed = getComputedStyle(host);
+    expect(computed.display).toBe('block');
+  });
 });

--- a/projects/design-angular-kit/src/lib/components/core/pagination/pagination.component.ts
+++ b/projects/design-angular-kit/src/lib/components/core/pagination/pagination.component.ts
@@ -13,6 +13,7 @@ import { inputToBoolean } from '../../../utils/coercion';
   templateUrl: './pagination.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [ItIconComponent, TranslateModule, LowerCasePipe, ItDropdownModule, ItInputComponent, ReactiveFormsModule],
+  host: { style: 'display: block' },
 })
 export class ItPaginationComponent implements OnChanges {
   /**


### PR DESCRIPTION
## Summary

Adds `host: { style: 'display: block' }` to `ItPaginationComponent`, fixing two related issues:

### #570 — Phantom margin-bottom
Without `display: block`, the `<it-pagination>` host element renders as an inline element. Inner elements' margins leak through the host, causing an unexpected phantom margin-bottom on the component.

### #571 — Margin utility classes have no effect
Utility classes like `mt-3`, `mb-3` applied to `<it-pagination>` are ignored because margins don't apply to inline elements.

## Fix
`host: { style: 'display: block' }` ensures the component behaves as a block-level element, allowing both proper margin isolation and full utility-class support.

This is the same pattern used in other components (e.g., `it-card`, `it-chip`).

## Testing
- Added regression test verifying `display: block` on the host element
- All 110 unit tests pass
- 0 lint errors

Fixes #570
Fixes #571