### PR TITLE
fix(deps): widen Angular peer dependency ranges to ^21.0.0 (#593)

### DIFF
--- a/projects/design-angular-kit/package.json
+++ b/projects/design-angular-kit/package.json
@@ -52,11 +52,11 @@
     "tslib": "^2.6.3"
   },
   "peerDependencies": {
-    "@angular/animations": "^21.2.1",
-    "@angular/common": "^21.2.1",
-    "@angular/core": "^21.2.1",
-    "@angular/platform-browser": "^21.2.1",
-    "@angular/router": "^21.2.1",
+    "@angular/animations": "^21.0.0",
+    "@angular/common": "^21.0.0",
+    "@angular/core": "^21.0.0",
+    "@angular/platform-browser": "^21.0.0",
+    "@angular/router": "^21.0.0",
     "@ngx-translate/core": "^17.0.0",
     "@ngx-translate/http-loader": "^17.0.0",
     "bootstrap-italia": "^2.17.4"


### PR DESCRIPTION
## Fixes #593

### Problem

Installing `design-angular-kit` with Angular 21 can fail with `ERESOLVE` errors when Angular packages resolve to different patch versions. For example, if the consumer has `@angular/core@21.2.0` but the library requires `@angular/animations@^21.2.1` (which resolves to `21.2.2`, requiring `@angular/core@21.2.2`), npm cannot satisfy both constraints.

This is the same class of issue reported in #593 for v20, where `^20.3.15` peer deps caused conflicts.

### Fix

Widen all Angular peer dependencies from `^21.2.1` to `^21.0.0`. This follows the standard Angular library practice (used by Angular Material, ngx-translate, etc.) of accepting any minor/patch version within the major range.

| Package | Before | After |
|---------|--------|-------|
| @angular/animations | ^21.2.1 | ^21.0.0 |
| @angular/common | ^21.2.1 | ^21.0.0 |
| @angular/core | ^21.2.1 | ^21.0.0 |
| @angular/platform-browser | ^21.2.1 | ^21.0.0 |
| @angular/router | ^21.2.1 | ^21.0.0 |

The `@ngx-translate` peer deps are already at `^17.0.0` on main, which resolves the second part of #593.

### Verification

- ✅ 109/109 unit tests passing
- ✅ 0 lint errors