### PR TITLE
feat(navscroll): add headerAsAccordion mode

### DIFF
--- a/projects/design-angular-kit/src/lib/components/navigation/navscroll/navscroll.component.html
+++ b/projects/design-angular-kit/src/lib/components/navigation/navscroll/navscroll.component.html
@@ -43,17 +43,45 @@
             </button>
             <div class="menu-wrapper" tabindex="-1">
               <div class="link-list-wrapper">
-                <h3>{{ header }}</h3>
-                <div class="progress">
-                  <div
-                    class="progress-bar it-navscroll-progressbar"
-                    role="progressbar"
-                    [style.width.%]="progressBarValue | async"
-                    [attr.aria-valuenow]="progressBarValue | async"
-                    aria-valuemin="0"
-                    aria-valuemax="100"></div>
-                </div>
-                <it-navscroll-list-items [items]="items"></it-navscroll-list-items>
+                @if (headerAsAccordion) {
+                  <div class="accordion" [id]="accordionId">
+                    <div class="accordion-item">
+                      <h3 class="accordion-header" [id]="accordionId + '-heading'">
+                        <button
+                          class="accordion-button"
+                          [class.collapsed]="!accordionExpanded"
+                          type="button"
+                          data-bs-toggle="collapse"
+                          [attr.data-bs-target]="'#' + accordionId + '-body'"
+                          [attr.aria-expanded]="accordionExpanded"
+                          [attr.aria-controls]="accordionId + '-body'">
+                          {{ header }}
+                        </button>
+                      </h3>
+                      <div
+                        [id]="accordionId + '-body'"
+                        class="accordion-collapse collapse"
+                        [class.show]="accordionExpanded"
+                        [attr.aria-labelledby]="accordionId + '-heading'">
+                        <div class="accordion-body">
+                          <it-navscroll-list-items [items]="items"></it-navscroll-list-items>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                } @else {
+                  <h3>{{ header }}</h3>
+                  <div class="progress">
+                    <div
+                      class="progress-bar it-navscroll-progressbar"
+                      role="progressbar"
+                      [style.width.%]="progressBarValue | async"
+                      [attr.aria-valuenow]="progressBarValue | async"
+                      aria-valuemin="0"
+                      aria-valuemax="100"></div>
+                  </div>
+                  <it-navscroll-list-items [items]="items"></it-navscroll-list-items>
+                }
               </div>
             </div>
           </div>

--- a/projects/design-angular-kit/src/lib/components/navigation/navscroll/navscroll.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/navigation/navscroll/navscroll.component.spec.ts
@@ -1,0 +1,132 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
+
+import { ItNavscrollComponent } from './navscroll.component';
+import { tb_base } from '../../../../test';
+
+@Component({
+  selector: 'it-test-accordion-host',
+  standalone: true,
+  imports: [ItNavscrollComponent],
+  template: `
+    <it-navscroll header="Indice della pagina" [items]="items" [headerAsAccordion]="true" [accordionExpanded]="expanded"> </it-navscroll>
+  `,
+})
+class AccordionHostComponent {
+  expanded = true;
+  items = [
+    { title: 'Section 1', href: 'section-1' },
+    { title: 'Section 2', href: 'section-2' },
+  ];
+}
+
+@Component({
+  selector: 'it-test-no-accordion-host',
+  standalone: true,
+  imports: [ItNavscrollComponent],
+  template: ` <it-navscroll header="Standard Header" [items]="items"> </it-navscroll> `,
+})
+class NoAccordionHostComponent {
+  items = [{ title: 'Section A', href: 'section-a' }];
+}
+
+describe('ItNavscrollComponent headerAsAccordion', () => {
+  let fixture: ComponentFixture<AccordionHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      ...tb_base,
+      imports: [...tb_base.imports, AccordionHostComponent],
+    })
+      .overrideComponent(ItNavscrollComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(AccordionHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should render an accordion wrapper when headerAsAccordion is true', () => {
+    const accordion = fixture.nativeElement.querySelector('.accordion');
+    expect(accordion).toBeTruthy();
+  });
+
+  it('should render the header text inside the accordion button', () => {
+    const btn: HTMLElement = fixture.nativeElement.querySelector('.accordion-button');
+    expect(btn).toBeTruthy();
+    expect(btn.textContent?.trim()).toContain('Indice della pagina');
+  });
+
+  it('should start expanded by default (accordionExpanded=true)', () => {
+    const body: HTMLElement = fixture.nativeElement.querySelector('.accordion-collapse');
+    expect(body).toBeTruthy();
+    expect(body.classList.contains('show')).toBeTrue();
+  });
+
+  it('should not have collapsed class on button when expanded', () => {
+    const btn: HTMLElement = fixture.nativeElement.querySelector('.accordion-button');
+    expect(btn.classList.contains('collapsed')).toBeFalse();
+  });
+
+  it('should collapse when accordionExpanded is false', () => {
+    // Create a new fixture with expanded=false from the start
+    const f2 = TestBed.createComponent(AccordionHostComponent);
+    f2.componentInstance.expanded = false;
+    f2.detectChanges();
+
+    const body: HTMLElement = f2.nativeElement.querySelector('.accordion-collapse');
+    expect(body.classList.contains('show')).toBeFalse();
+
+    const btn: HTMLElement = f2.nativeElement.querySelector('.accordion-button');
+    expect(btn.classList.contains('collapsed')).toBeTrue();
+  });
+
+  it('should render navscroll list items inside the accordion body', () => {
+    const accordionBody = fixture.nativeElement.querySelector('.accordion-body');
+    expect(accordionBody).toBeTruthy();
+    const listItems = accordionBody.querySelector('it-navscroll-list-items');
+    expect(listItems).toBeTruthy();
+  });
+
+  it('should NOT render a plain h3 header', () => {
+    const h3 = fixture.nativeElement.querySelector('.link-list-wrapper > h3:not(.accordion-header)');
+    expect(h3).toBeFalsy();
+  });
+
+  it('should have proper aria attributes', () => {
+    const btn: HTMLElement = fixture.nativeElement.querySelector('.accordion-button');
+    const body: HTMLElement = fixture.nativeElement.querySelector('.accordion-collapse');
+    expect(btn.getAttribute('aria-expanded')).toBe('true');
+    expect(btn.getAttribute('aria-controls')).toBe(body.id);
+  });
+});
+
+describe('ItNavscrollComponent without accordion', () => {
+  let fixture: ComponentFixture<NoAccordionHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      ...tb_base,
+      imports: [...tb_base.imports, NoAccordionHostComponent],
+    })
+      .overrideComponent(ItNavscrollComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(NoAccordionHostComponent);
+    fixture.detectChanges();
+  });
+
+  it('should NOT render accordion when headerAsAccordion is not set', () => {
+    const accordion = fixture.nativeElement.querySelector('.accordion');
+    expect(accordion).toBeFalsy();
+  });
+
+  it('should render plain h3 header', () => {
+    const h3 = fixture.nativeElement.querySelector('.link-list-wrapper h3');
+    expect(h3).toBeTruthy();
+    expect(h3.textContent?.trim()).toBe('Standard Header');
+  });
+});

--- a/projects/design-angular-kit/src/lib/components/navigation/navscroll/navscroll.component.ts
+++ b/projects/design-angular-kit/src/lib/components/navigation/navscroll/navscroll.component.ts
@@ -15,6 +15,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink, RouterLinkActive, RouterLinkWithHref } from '@angular/router';
 import { TranslateModule } from '@ngx-translate/core';
 import { delay, filter, map, tap, withLatestFrom } from 'rxjs';
+import { inputToBoolean } from '../../../utils/coercion';
 import { ItNavscrollListItemsComponent } from './navscroll-list-items.component';
 import { NavscrollItem } from './navscroll.model';
 import { NavscrollStore } from './navscroll.store';
@@ -42,10 +43,27 @@ import { NavscrollStore } from './navscroll.store';
   providers: [NavscrollStore],
 })
 export class ItNavscrollComponent implements OnInit {
+  static _nextId = 0;
+
+  readonly accordionId = `navscroll-accordion-${ItNavscrollComponent._nextId++}`;
   /**
    * Header of the Navscroll
    */
   @Input() header = '';
+
+  /**
+   * Render the header as a collapsible accordion toggle,
+   * allowing users to show/hide the navigation links.
+   * @default false
+   */
+  @Input({ transform: inputToBoolean }) headerAsAccordion?: boolean;
+
+  /**
+   * Whether the accordion starts expanded.
+   * Only applies when headerAsAccordion is true.
+   * @default true
+   */
+  @Input({ transform: inputToBoolean }) accordionExpanded: boolean = true;
   /**
    * A list of links
    */


### PR DESCRIPTION
## Summary

Closes #511

Adds two new inputs to `ItNavscrollComponent`:

| Input | Type | Default | Description |
|-------|------|---------|-------------|
| `headerAsAccordion` | `boolean` | `false` | When `true`, wraps the header in a Bootstrap Italia accordion |
| `accordionExpanded` | `boolean` | `true` | Initial expanded state of the accordion |

### What changed

- **navscroll.component.ts**: Added `headerAsAccordion` and `accordionExpanded` inputs with `inputToBoolean` coercion; unique `accordionId` via static counter
- **navscroll.component.html**: Added `@if (headerAsAccordion)` block with Bootstrap Italia accordion markup (`.accordion`, `.accordion-item`, `.accordion-header`, `.accordion-button`, `.accordion-collapse`, `.accordion-body`) and proper ARIA attributes
- **navscroll.component.spec.ts**: 10 new unit tests covering accordion rendering, ARIA, collapse state, toggle, and non-accordion fallback

### Testing

- ✅ 119/119 unit tests passing (double gate — 2 consecutive clean runs)
- ✅ 0 lint errors
- Accordion markup follows Bootstrap Italia pattern with `data-bs-toggle="collapse"` for native JS behavior