### PR TITLE
feat(header): add showMobileMenu input to toggle hamburger menu

### DIFF
--- a/projects/design-angular-kit/src/lib/components/navigation/header/header.component.html
+++ b/projects/design-angular-kit/src/lib/components/navigation/header/header.component.html
@@ -88,7 +88,7 @@
       <div class="container">
         <div class="row">
           <div class="col-12">
-            <it-navbar [megamenu]="megamenu" [expand]="expand">
+            <it-navbar [megamenu]="megamenu" [expand]="expand" [showMobileMenu]="showMobileMenu">
               <ng-container navItems>
                 <ng-content select="[navItems]"></ng-content>
               </ng-container>

--- a/projects/design-angular-kit/src/lib/components/navigation/header/header.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/navigation/header/header.component.spec.ts
@@ -1,3 +1,4 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ItHeaderComponent } from './header.component';
@@ -17,5 +18,76 @@ describe('ItHeaderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+/* ───────────────────────────────────────────── *
+ *  showMobileMenu — hamburger menu toggle       *
+ * ───────────────────────────────────────────── */
+
+@Component({
+  selector: 'it-test-header-mobile-menu',
+  template: `<it-header [showMobileMenu]="showMobileMenu"></it-header>`,
+  imports: [ItHeaderComponent],
+})
+class HeaderMobileMenuHost {
+  showMobileMenu: boolean | undefined = true;
+}
+
+describe('ItHeaderComponent — showMobileMenu', () => {
+  let fixture: ComponentFixture<HeaderMobileMenuHost>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      ...tb_base,
+      imports: [...(tb_base as any).imports, HeaderMobileMenuHost],
+    })
+      .overrideComponent(ItHeaderComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
+  });
+
+  function createFixture(showMobile: boolean | undefined): ComponentFixture<HeaderMobileMenuHost> {
+    const f = TestBed.createComponent(HeaderMobileMenuHost);
+    f.componentInstance.showMobileMenu = showMobile;
+    f.detectChanges();
+    return f;
+  }
+
+  it('should render the hamburger toggler by default (showMobileMenu=true)', () => {
+    fixture = createFixture(true);
+    const toggler = fixture.nativeElement.querySelector('.custom-navbar-toggler');
+    expect(toggler).toBeTruthy();
+  });
+
+  it('should render the offcanvas sidebar by default (showMobileMenu=true)', () => {
+    fixture = createFixture(true);
+    const collapsable = fixture.nativeElement.querySelector('.navbar-collapsable');
+    expect(collapsable).toBeTruthy();
+  });
+
+  it('should hide the hamburger toggler when showMobileMenu=false', () => {
+    fixture = createFixture(false);
+    const toggler = fixture.nativeElement.querySelector('.custom-navbar-toggler');
+    expect(toggler).toBeNull();
+  });
+
+  it('should hide the offcanvas sidebar when showMobileMenu=false', () => {
+    fixture = createFixture(false);
+    const collapsable = fixture.nativeElement.querySelector('.navbar-collapsable');
+    expect(collapsable).toBeNull();
+  });
+
+  it('should still render the nav items when showMobileMenu=false', () => {
+    fixture = createFixture(false);
+    const menuWrapper = fixture.nativeElement.querySelector('.menu-wrapper');
+    expect(menuWrapper).toBeTruthy();
+  });
+
+  it('should still render the nav items when showMobileMenu=true', () => {
+    fixture = createFixture(true);
+    const menuWrapper = fixture.nativeElement.querySelector('.menu-wrapper');
+    expect(menuWrapper).toBeTruthy();
   });
 });

--- a/projects/design-angular-kit/src/lib/components/navigation/header/header.component.ts
+++ b/projects/design-angular-kit/src/lib/components/navigation/header/header.component.ts
@@ -55,6 +55,13 @@ export class ItHeaderComponent implements AfterViewInit, OnChanges {
   @Input({ transform: inputToBoolean }) megamenu?: boolean;
   @Input({ transform: inputToBoolean }) expand?: boolean = true;
 
+  /**
+   * Show the mobile hamburger menu and offcanvas sidebar.
+   * Set to false to hide the mobile navigation toggle.
+   * @default true
+   */
+  @Input({ transform: inputToBoolean }) showMobileMenu?: boolean = true;
+
   private stickyHeader?: HeaderSticky;
 
   constructor() {

--- a/projects/design-angular-kit/src/lib/components/navigation/navbar/navbar/navbar.component.html
+++ b/projects/design-angular-kit/src/lib/components/navigation/navbar/navbar/navbar.component.html
@@ -3,25 +3,33 @@
   [class.navbar-expand-lg]="expand"
   [class.has-megamenu]="megamenu"
   [attr.aria-label]="'it.navbar.aria-label-main' | translate">
-  <button
-    (click)="toggleCollapse()"
-    #collapseButton
-    class="custom-navbar-toggler"
-    type="button"
-    [attr.aria-label]="'it.navbar.aria-label-toggle' | translate">
-    <it-icon name="burger"></it-icon>
-  </button>
-  <div #collapseView class="navbar-collapsable" tabindex="-1">
-    <div class="close-div">
-      <button class="btn close-menu" type="button">
-        <span class="visually-hidden">{{ 'it.navbar.hide' | translate }}</span>
-        <it-icon name="close-big"></it-icon>
-      </button>
+  @if (showMobileMenu) {
+    <button
+      (click)="toggleCollapse()"
+      #collapseButton
+      class="custom-navbar-toggler"
+      type="button"
+      [attr.aria-label]="'it.navbar.aria-label-toggle' | translate">
+      <it-icon name="burger"></it-icon>
+    </button>
+    <div #collapseView class="navbar-collapsable" tabindex="-1">
+      <div class="close-div">
+        <button class="btn close-menu" type="button">
+          <span class="visually-hidden">{{ 'it.navbar.hide' | translate }}</span>
+          <it-icon name="close-big"></it-icon>
+        </button>
+      </div>
+      <div class="menu-wrapper">
+        <ul class="navbar-nav">
+          <ng-content select="[navItems]"></ng-content>
+        </ul>
+      </div>
     </div>
+  } @else {
     <div class="menu-wrapper">
       <ul class="navbar-nav">
         <ng-content select="[navItems]"></ng-content>
       </ul>
     </div>
-  </div>
+  }
 </nav>

--- a/projects/design-angular-kit/src/lib/components/navigation/navbar/navbar/navbar.component.ts
+++ b/projects/design-angular-kit/src/lib/components/navigation/navbar/navbar/navbar.component.ts
@@ -15,6 +15,13 @@ export class ItNavBarComponent implements AfterViewInit {
   @Input({ transform: inputToBoolean }) megamenu?: boolean;
   @Input({ transform: inputToBoolean }) expand?: boolean = true;
 
+  /**
+   * Show the mobile hamburger menu and offcanvas sidebar.
+   * Set to false to hide the mobile navigation toggle.
+   * @default true
+   */
+  @Input({ transform: inputToBoolean }) showMobileMenu?: boolean = true;
+
   @ViewChild('collapseButton') private collapseButton?: ElementRef<HTMLButtonElement>;
   @ViewChild('collapseView') private collapseView?: ElementRef<HTMLButtonElement>;
 


### PR DESCRIPTION
## Summary

Closes #466 — Header without sidebar on mobile

Adds a new `showMobileMenu` boolean input (default `true`) to both `ItHeaderComponent` and `ItNavBarComponent`.

When `showMobileMenu` is set to `false`:
- The mobile hamburger toggler button (`.custom-navbar-toggler`) is hidden
- The offcanvas sidebar (`.navbar-collapsable`) is hidden
- Navigation items remain fully visible in the desktop menu wrapper

This allows developers to use the header for pages that have no sidebar or mobile navigation needs, as discussed in #466.

### Changes
- **`ItNavBarComponent`** — new `@Input showMobileMenu` with `inputToBoolean` transform; template wrapped in `@if` block
- **`ItHeaderComponent`** — new `@Input showMobileMenu` forwarded to `<it-navbar>`
- **Tests** — 6 new test cases covering show/hide hamburger and offcanvas behavior

> ⚠️ Note: This reopens #653 which was accidentally closed due to fork deletion.