### PR TITLE
fix(alert): hide empty <h4> heading when no content is projected

### DIFF
--- a/projects/design-angular-kit/src/lib/components/core/alert/alert.component.html
+++ b/projects/design-angular-kit/src/lib/components/core/alert/alert.component.html
@@ -5,7 +5,7 @@
   [class.fade]="dismissible"
   [class.show]="dismissible"
   role="alert">
-  <h4 class="alert-heading">
+  <h4 class="alert-heading" #headingEl [class.d-none]="!hasHeading()" [attr.aria-hidden]="!hasHeading()">
     <ng-content select="[heading]"></ng-content>
   </h4>
 

--- a/projects/design-angular-kit/src/lib/components/core/alert/alert.component.scss
+++ b/projects/design-angular-kit/src/lib/components/core/alert/alert.component.scss
@@ -1,3 +1,0 @@
-.alert-heading:empty {
-  display: none;
-}

--- a/projects/design-angular-kit/src/lib/components/core/alert/alert.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/core/alert/alert.component.spec.ts
@@ -29,12 +29,31 @@ class UnitTestComponent {
   private _dismissible: boolean = false;
 }
 
+@Component({
+  selector: 'it-unit-test-with-heading',
+  template: `
+    <it-alert [color]="'info'">
+      <span heading>Titolo di test</span>
+      Contenuto dell'alert.
+    </it-alert>
+  `,
+  standalone: false,
+})
+class UnitTestWithHeadingComponent {}
+
+@Component({
+  selector: 'it-unit-test-without-heading',
+  template: ` <it-alert [color]="'warning'"> Alert senza heading. </it-alert> `,
+  standalone: false,
+})
+class UnitTestWithoutHeadingComponent {}
+
 let component: UnitTestComponent;
 let fixture: ComponentFixture<UnitTestComponent>;
 describe('ItAlertComponent', () => {
   beforeEach(async () => {
     TestBed.configureTestingModule({
-      declarations: [UnitTestComponent],
+      declarations: [UnitTestComponent, UnitTestWithHeadingComponent, UnitTestWithoutHeadingComponent],
       imports: [ItAlertComponent],
     }).compileComponents();
 
@@ -59,5 +78,49 @@ describe('ItAlertComponent', () => {
     fixture.detectChanges();
     const spanElement = fixture.debugElement.query(By.css('div.alert.alert-success'));
     expect(spanElement).toBeTruthy();
+  });
+
+  describe('Bug #547 — empty h4 heading', () => {
+    it('should hide the h4 element when no heading content is projected', () => {
+      const noHeadingFixture = TestBed.createComponent(UnitTestWithoutHeadingComponent);
+      noHeadingFixture.detectChanges();
+
+      const h4 = noHeadingFixture.debugElement.query(By.css('h4.alert-heading'));
+      expect(h4).toBeTruthy('h4 element should exist in DOM');
+      expect(h4.nativeElement.classList.contains('d-none')).toBeTrue();
+    });
+
+    it('should mark empty heading as aria-hidden for screen readers', () => {
+      const noHeadingFixture = TestBed.createComponent(UnitTestWithoutHeadingComponent);
+      noHeadingFixture.detectChanges();
+
+      const h4 = noHeadingFixture.debugElement.query(By.css('h4.alert-heading'));
+      expect(h4.nativeElement.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('should show the h4 element when heading content is projected', () => {
+      const withHeadingFixture = TestBed.createComponent(UnitTestWithHeadingComponent);
+      withHeadingFixture.detectChanges();
+
+      const h4 = withHeadingFixture.debugElement.query(By.css('h4.alert-heading'));
+      expect(h4).toBeTruthy('h4 element should exist in DOM');
+      expect(h4.nativeElement.classList.contains('d-none')).toBeFalse();
+    });
+
+    it('should not mark visible heading as aria-hidden', () => {
+      const withHeadingFixture = TestBed.createComponent(UnitTestWithHeadingComponent);
+      withHeadingFixture.detectChanges();
+
+      const h4 = withHeadingFixture.debugElement.query(By.css('h4.alert-heading'));
+      expect(h4.nativeElement.getAttribute('aria-hidden')).toBe('false');
+    });
+
+    it('should have visible heading text when heading is projected', () => {
+      const withHeadingFixture = TestBed.createComponent(UnitTestWithHeadingComponent);
+      withHeadingFixture.detectChanges();
+
+      const h4 = withHeadingFixture.debugElement.query(By.css('h4.alert-heading'));
+      expect(h4.nativeElement.textContent.trim()).toBe('Titolo di test');
+    });
   });
 });

--- a/projects/design-angular-kit/src/lib/components/core/alert/alert.component.ts
+++ b/projects/design-angular-kit/src/lib/components/core/alert/alert.component.ts
@@ -1,4 +1,14 @@
-import { AfterViewInit, ChangeDetectionStrategy, Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  signal,
+  ViewChild,
+} from '@angular/core';
 import { AlertColor } from '../../../interfaces/core';
 import { ItAbstractComponent } from '../../../abstracts/abstract.component';
 import { Alert } from 'bootstrap-italia';
@@ -41,12 +51,20 @@ export class ItAlertComponent extends ItAbstractComponent implements AfterViewIn
    */
   @Output() public closedEvent: EventEmitter<Event> = new EventEmitter();
 
+  /**
+   * Whether the heading slot has projected content.
+   * Drives the [class.d-none] and [attr.aria-hidden] bindings on the `<h4>`.
+   */
+  readonly hasHeading = signal(false);
+
   private alert?: Alert;
 
   @ViewChild('alertElement') private alertElement?: ElementRef<HTMLDivElement>;
+  @ViewChild('headingEl') private headingEl?: ElementRef<HTMLHeadingElement>;
 
   override ngAfterViewInit() {
     super.ngAfterViewInit();
+    this._detectHeadingContent();
 
     if (this.alertElement) {
       const element = this.alertElement.nativeElement;
@@ -70,5 +88,20 @@ export class ItAlertComponent extends ItAbstractComponent implements AfterViewIn
    */
   public dispose(): void {
     this.alert?.dispose();
+  }
+
+  /**
+   * Checks whether the heading `<ng-content>` slot received real projected content.
+   * Ignores Angular comment nodes and whitespace-only text nodes.
+   */
+  private _detectHeadingContent(): void {
+    const el = this.headingEl?.nativeElement;
+    if (!el) {
+      return;
+    }
+    const hasContent = Array.from(el.childNodes).some(
+      node => node.nodeType === Node.ELEMENT_NODE || (node.nodeType === Node.TEXT_NODE && (node.textContent?.trim() ?? '') !== '')
+    );
+    this.hasHeading.set(hasContent);
   }
 }


### PR DESCRIPTION
## Closes #547

### Problem
When no content is projected into the `[heading]` slot, the `<h4 class="alert-heading">` element is rendered empty in the DOM, producing invalid markup and visual spacing artifacts.

### Root Cause
The template always rendered the `<h4>` element regardless of whether `<ng-content select="[heading]">` had any projected content. The existing CSS `:empty` pseudo-class workaround in the SCSS file was unreliable because Angular comment nodes prevented `:empty` from matching.

### Fix
- **Runtime content detection**: Added `_detectHeadingContent()` method that scans the heading element child nodes after view init, ignoring Angular comment nodes and whitespace-only text nodes.
- **Signal-driven visibility**: A `hasHeading` signal controls both `[class.d-none]` (visual hiding) and `[attr.aria-hidden]` (screen-reader hiding) on the `<h4>` element.
- **Removed broken SCSS hack**: Deleted the CSS `:empty` pseudo-class rule that never worked reliably with Angular.

### Tests
- **5 new unit tests** under `Bug #547` describe block:
  - Empty heading is hidden (`d-none` class applied)
  - Empty heading has `aria-hidden="true"`
  - Heading with content is visible (`d-none` not applied)
  - Visible heading has `aria-hidden="false"`
  - Projected heading text content matches expected value
- **Full test suite**: 114/114 passing ✅
- **Lint**: 0 errors (8 pre-existing warnings unchanged) ✅
- **Library build**: Clean ✅

### E2E Proof (Live Demo App)
Tested on the running demo app at `/#/componenti/alert` — 9 `it-alert` components verified:

| Alert | Has Heading Content | `d-none` | `aria-hidden` | `display` | Verdict |
|-------|-------------------|----------|--------------|-----------|---------|
| #0–#5, #7–#8 | ❌ No | ✅ true | ✅ true | none | ✅ PASS |
| #6 ("Avviso di successo!") | ✅ Yes | ✅ false | ✅ false | block | ✅ PASS |

**All 9 checks passed** — empty headings are correctly hidden from both visual layout and assistive technologies, while headings with content remain fully visible.

### Changed Files
- `alert.component.ts` — Added `hasHeading` signal + `_detectHeadingContent()` method
- `alert.component.html` — Added `[class.d-none]` and `[attr.aria-hidden]` bindings
- `alert.component.scss` — Removed broken `:empty` CSS hack
- `alert.component.spec.ts` — Added 5 strict regression tests + 2 test wrapper components


> ⚠️ This reopens #611 which was accidentally closed due to fork deletion.