### PR TITLE
fix(chip): reset unwanted margins from bootstrap-italia (#542)

### DIFF
--- a/projects/design-angular-kit/src/lib/components/core/chip/chip.component.scss
+++ b/projects/design-angular-kit/src/lib/components/core/chip/chip.component.scss
@@ -1,0 +1,11 @@
+// Reset unwanted margins applied by bootstrap-italia's .chip class.
+// The parent container should control spacing, not the chip itself.
+// Fixes #542.
+.chip {
+  margin-top: 0;
+  margin-bottom: 0;
+
+  &:not(:last-child) {
+    margin-right: 0;
+  }
+}

--- a/projects/design-angular-kit/src/lib/components/core/chip/chip.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/core/chip/chip.component.spec.ts
@@ -1,9 +1,20 @@
-import { ChangeDetectionStrategy } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
 import { tb_base } from '../../../../test';
 import { ItChipComponent } from './chip.component';
+
+@Component({
+  selector: 'it-test-chip-group',
+  template: `
+    <it-chip label="Chip A"></it-chip>
+    <it-chip label="Chip B"></it-chip>
+    <it-chip label="Chip C"></it-chip>
+  `,
+  imports: [ItChipComponent],
+})
+class ChipGroupTestComponent {}
 
 describe('ItChipComponent', () => {
   let component: ItChipComponent;
@@ -83,5 +94,43 @@ describe('ItChipComponent', () => {
       By.css('img[alt="alt"][src="https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png"]')
     );
     expect(imgElement).toBeTruthy();
+  });
+
+  describe('Bug #542 — unwanted margins', () => {
+    it('should have margin-top: 0px on the .chip element', () => {
+      component.label = 'Test chip';
+      fixture.detectChanges();
+      const chipEl = fixture.debugElement.query(By.css('.chip'));
+      expect(chipEl).toBeTruthy();
+      const style = getComputedStyle(chipEl.nativeElement);
+      expect(style.marginTop).toBe('0px');
+    });
+
+    it('should have margin-bottom: 0px on the .chip element', () => {
+      component.label = 'Test chip';
+      fixture.detectChanges();
+      const chipEl = fixture.debugElement.query(By.css('.chip'));
+      const style = getComputedStyle(chipEl.nativeElement);
+      expect(style.marginBottom).toBe('0px');
+    });
+
+    it('should have margin-right: 0px on .chip:not(:last-child)', () => {
+      const groupFixture = TestBed.createComponent(ChipGroupTestComponent);
+      groupFixture.detectChanges();
+      const chips = groupFixture.debugElement.queryAll(By.css('.chip'));
+      expect(chips.length).toBe(3);
+      const firstChipStyle = getComputedStyle(chips[0].nativeElement);
+      expect(firstChipStyle.marginRight).toBe('0px');
+    });
+
+    it('should have all margins at 0px on the large chip variant', () => {
+      component.label = 'Large chip';
+      component.size = 'lg';
+      fixture.detectChanges();
+      const chipEl = fixture.debugElement.query(By.css('.chip'));
+      const style = getComputedStyle(chipEl.nativeElement);
+      expect(style.marginTop).toBe('0px');
+      expect(style.marginBottom).toBe('0px');
+    });
   });
 });

--- a/projects/design-angular-kit/src/lib/components/core/chip/chip.component.ts
+++ b/projects/design-angular-kit/src/lib/components/core/chip/chip.component.ts
@@ -8,6 +8,7 @@ import { IT_ASSET_BASE_PATH } from '../../../interfaces/design-angular-kit-confi
 @Component({
   selector: 'it-chip',
   templateUrl: './chip.component.html',
+  styleUrls: ['./chip.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgClass, TranslateModule],
 })


### PR DESCRIPTION
## Summary

Fixes #542 — The `<it-chip>` component inherits unwanted `margin-top`, `margin-bottom`, and `margin-right` from bootstrap-italia's `.chip` class. These margins break predictable layouts when chips are composed inside custom containers.

## Root cause

bootstrap-italia's `_chips.scss` applies:
- `margin-top: $v-gap * 0.5`
- `margin-bottom: $v-gap`
- `&:not(:last-child) { margin-right: $v-gap }`

The Angular component had no `styleUrl`, so it could not override these global styles.

## Solution

- Created `chip.component.scss` with scoped margin resets (`margin-top: 0`, `margin-bottom: 0`, `margin-right: 0`)
- Added `styleUrls` to the `@Component` decorator so Angular's `ViewEncapsulation.Emulated` gives the resets higher specificity than the global bootstrap-italia styles
- Parent containers should handle spacing between chips, not the chip itself

## Testing

- **4 new unit tests** covering:
  - margin-top = 0px verification
  - margin-bottom = 0px verification
  - margin-right = 0px on :not(:last-child) in a 3-chip group
  - All margins = 0px on the `chip-lg` variant
- **Full test suite: 113/113 PASS**, 0 lint errors, library builds clean

> ⚠️ This reopens #613 which was accidentally closed due to fork deletion.