### PR TITLE
feat(figure): add ItFigureDirective that auto-applies .figure class (#543)

### DIFF
--- a/projects/design-angular-kit/src/lib/components/core/figure/figure.directive.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/core/figure/figure.directive.spec.ts
@@ -1,0 +1,107 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { ItFigureDirective } from './figure.directive';
+
+@Component({
+  selector: 'it-test-figure-basic',
+  template: `
+    <it-figure>
+      <img src="https://placeholderimage.eu/api/city/400/300" alt="City view" />
+    </it-figure>
+  `,
+  imports: [ItFigureDirective],
+})
+class BasicFigureTestComponent {}
+
+@Component({
+  selector: 'it-test-figure-caption',
+  template: `
+    <it-figure>
+      <img src="https://placeholderimage.eu/api/city/400/300" alt="City view" />
+      <figcaption class="figure-caption">A beautiful Italian cityscape</figcaption>
+    </it-figure>
+  `,
+  imports: [ItFigureDirective],
+})
+class FigureWithCaptionTestComponent {}
+
+@Component({
+  selector: 'it-test-figure-extra-class',
+  template: `
+    <it-figure class="img-full">
+      <img src="https://placeholderimage.eu/api/city/800/600" alt="Full-width city view" />
+    </it-figure>
+  `,
+  imports: [ItFigureDirective],
+})
+class FigureWithExtraClassTestComponent {}
+
+describe('ItFigureDirective', () => {
+  describe('basic usage', () => {
+    let fixture: ComponentFixture<BasicFigureTestComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [BasicFigureTestComponent],
+      }).compileComponents();
+      fixture = TestBed.createComponent(BasicFigureTestComponent);
+      fixture.detectChanges();
+    });
+
+    it('should create the host element', () => {
+      const figureEl = fixture.debugElement.query(By.directive(ItFigureDirective));
+      expect(figureEl).toBeTruthy();
+    });
+
+    it('should automatically apply the "figure" CSS class to the host', () => {
+      const figureEl = fixture.debugElement.query(By.directive(ItFigureDirective));
+      expect(figureEl.nativeElement.classList.contains('figure')).toBeTrue();
+    });
+
+    it('should project the <img> child into the host', () => {
+      const img = fixture.debugElement.query(By.css('it-figure img'));
+      expect(img).toBeTruthy();
+      expect(img.nativeElement.getAttribute('alt')).toBe('City view');
+    });
+  });
+
+  describe('with caption', () => {
+    let fixture: ComponentFixture<FigureWithCaptionTestComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [FigureWithCaptionTestComponent],
+      }).compileComponents();
+      fixture = TestBed.createComponent(FigureWithCaptionTestComponent);
+      fixture.detectChanges();
+    });
+
+    it('should project both <img> and <figcaption> into the host', () => {
+      const img = fixture.debugElement.query(By.css('it-figure img'));
+      const caption = fixture.debugElement.query(By.css('it-figure figcaption'));
+      expect(img).toBeTruthy();
+      expect(caption).toBeTruthy();
+      expect(caption.nativeElement.textContent).toContain('A beautiful Italian cityscape');
+    });
+  });
+
+  describe('with additional CSS classes', () => {
+    let fixture: ComponentFixture<FigureWithExtraClassTestComponent>;
+
+    beforeEach(async () => {
+      await TestBed.configureTestingModule({
+        imports: [FigureWithExtraClassTestComponent],
+      }).compileComponents();
+      fixture = TestBed.createComponent(FigureWithExtraClassTestComponent);
+      fixture.detectChanges();
+    });
+
+    it('should keep the "figure" class alongside consumer-added classes', () => {
+      const figureEl = fixture.debugElement.query(By.directive(ItFigureDirective));
+      expect(figureEl.nativeElement.classList.contains('figure')).toBeTrue();
+      expect(figureEl.nativeElement.classList.contains('img-full')).toBeTrue();
+    });
+  });
+});

--- a/projects/design-angular-kit/src/lib/components/core/figure/figure.directive.ts
+++ b/projects/design-angular-kit/src/lib/components/core/figure/figure.directive.ts
@@ -1,0 +1,22 @@
+import { Directive } from '@angular/core';
+
+/**
+ * Directive that automatically applies the `.figure` CSS class to the host
+ * element, so consumers do not need to add it manually.
+ *
+ * Usage:
+ * ```html
+ * <it-figure>
+ *   <img src="..." alt="..." />
+ *   <figcaption class="figure-caption">Caption text</figcaption>
+ * </it-figure>
+ * ```
+ *
+ * Fixes #543.
+ */
+@Directive({
+  standalone: true,
+  selector: 'it-figure',
+  host: { class: 'figure' },
+})
+export class ItFigureDirective {}

--- a/projects/design-angular-kit/src/lib/design-angular-kit.module.ts
+++ b/projects/design-angular-kit/src/lib/design-angular-kit.module.ts
@@ -12,6 +12,7 @@ import { ItChipComponent } from './components/core/chip/chip.component';
 import { ItCollapseComponent } from './components/core/collapse/collapse.component';
 import { ItDimmerModule } from './components/core/dimmer/dimmer.module';
 import { ItDropdownModule } from './components/core/dropdown/dropdown.module';
+import { ItFigureDirective } from './components/core/figure/figure.directive';
 import { ItForwardDirective } from './components/core/forward/forward.directive';
 import { ItLinkComponent } from './components/core/link/link.component';
 import { ItListModule } from './components/core/list/list.module';
@@ -63,6 +64,7 @@ const core = [
   ItCollapseComponent,
   ItDimmerModule,
   ItDropdownModule,
+  ItFigureDirective,
   ItForwardDirective,
   ItLinkComponent,
   ItListModule,

--- a/projects/design-angular-kit/src/public_api.ts
+++ b/projects/design-angular-kit/src/public_api.ts
@@ -39,6 +39,7 @@ export * from './lib/components/core/dropdown/dropdown-item/dropdown-item.compon
 export * from './lib/components/core/dropdown/dropdown.module';
 export * from './lib/components/core/dropdown/dropdown/dropdown.component';
 
+export * from './lib/components/core/figure/figure.directive';
 export * from './lib/components/core/forward/forward.directive';
 export * from './lib/components/core/link/link.component';
 


### PR DESCRIPTION
## Summary

Fixes #543 — When using `<it-figure>`, the `.figure` CSS class from bootstrap-italia is now automatically applied to the host element. Consumers no longer need to write `<it-figure class="figure">`.

## Solution

Created a lightweight standalone directive (`ItFigureDirective`) with:
- Selector: `it-figure`
- `host: { class: 'figure' }` — automatically adds the `.figure` class (same pattern as `ItForwardDirective`)

The directive is:
- Exported from `DesignAngularKitModule`
- Exported from `public_api.ts`

## Usage

```html
<it-figure class="figure">
  <img src="..." alt="..." />
</it-figure>

<it-figure>
  <img src="..." alt="..." />
  <figcaption class="figure-caption">Caption text</figcaption>
</it-figure>
```

Additional classes like `img-full` still work: `<it-figure class="img-full">`

## Testing

- **5 new unit tests** covering:
  - Directive creation
  - Automatic `.figure` class on host element
  - Content projection (`<img>` child)
  - Content projection with `<figcaption>`
  - Coexistence with consumer-added classes (`img-full`)
- **Full test suite: 114/114 PASS**, 0 lint errors, library builds clean

> ⚠️ This reopens #614 which was accidentally closed due to fork deletion.