### PR TITLE
fix(autocomplete): sync visual input with form control on reset (#550)

### DIFF
--- a/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.spec.ts
@@ -18,4 +18,32 @@ describe('ItAutocompleteComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should clear visual input value when writeValue receives null', () => {
+    // Simulate the internal _inputEl being set (as _findInput does after DOM init)
+    const fakeInput = document.createElement('input');
+    fakeInput.value = 'Roma';
+    (component as any)._inputEl = fakeInput;
+
+    component.writeValue(null);
+    expect(fakeInput.value).toBe('');
+  });
+
+  it('should clear visual input value when writeValue receives empty string', () => {
+    const fakeInput = document.createElement('input');
+    fakeInput.value = 'Milano';
+    (component as any)._inputEl = fakeInput;
+
+    component.writeValue('');
+    expect(fakeInput.value).toBe('');
+  });
+
+  it('should NOT clear visual input value when writeValue receives a non-empty string', () => {
+    const fakeInput = document.createElement('input');
+    fakeInput.value = 'Torino';
+    (component as any)._inputEl = fakeInput;
+
+    component.writeValue('Napoli');
+    expect(fakeInput.value).toBe('Torino');
+  });
 });

--- a/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.ts
+++ b/projects/design-angular-kit/src/lib/components/form/autocomplete/autocomplete.component.ts
@@ -108,6 +108,13 @@ export class ItAutocompleteComponent extends ItAbstractFormComponent<string | nu
     }
   }
 
+  override writeValue(value: string | null | undefined): void {
+    super.writeValue(value);
+    if (!value && this._inputEl) {
+      this.clear();
+    }
+  }
+
   clear() {
     (this._inputEl as HTMLInputElement).value = '';
   }


### PR DESCRIPTION
## Summary

Fixes #550 — `form.reset()` now correctly clears the autocomplete visual input.

## Problem

When `form.reset()` is called, the `FormControl` value becomes `null` but the autocomplete input's visual text remained unchanged. This happened because `writeValue()` in the abstract base class only updated the `FormControl` without clearing the underlying DOM input created by `SelectAutocomplete`.

## Solution

Override `writeValue()` in `ItAutocompleteComponent` to call `this.clear()` when the new value is nullish (`null`, `undefined`, or empty string), keeping the visual state in sync with the reactive form model. The guard `this._inputEl` ensures safety before DOM initialization.

## Changes

| File | What changed |
|------|-------------|
| `autocomplete.component.ts` | Added `writeValue()` override that calls `clear()` on null/empty values |

## Testing

- 3 new regression tests:
  - `writeValue(null)` clears visual input
  - `writeValue('')` clears visual input  
  - `writeValue('text')` preserves existing visual input
- All 112 existing tests pass ✅
- 0 lint errors ✅

## Verification

The fix targets the root cause: the abstract `writeValue()` only calls `control.setValue()` which updates the reactive form but not the DOM input. By overriding and adding `clear()` for falsy values, both layers stay synchronized.


> ⚠️ This reopens #618 which was accidentally closed due to fork deletion.