### PR TITLE
fix(chip): center label inside flex parent like it-list-item

### DIFF
--- a/projects/design-angular-kit/src/lib/components/core/chip/chip.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/core/chip/chip.component.spec.ts
@@ -84,4 +84,11 @@ describe('ItChipComponent', () => {
     );
     expect(imgElement).toBeTruthy();
   });
+
+  it('should render host as inline-block with vertical-align middle for flex-parent centering (#579)', () => {
+    const host = fixture.nativeElement as HTMLElement;
+    const computed = getComputedStyle(host);
+    expect(computed.display).toBe('inline-block');
+    expect(computed.verticalAlign).toBe('middle');
+  });
 });

--- a/projects/design-angular-kit/src/lib/components/core/chip/chip.component.ts
+++ b/projects/design-angular-kit/src/lib/components/core/chip/chip.component.ts
@@ -10,6 +10,7 @@ import { IT_ASSET_BASE_PATH } from '../../../interfaces/design-angular-kit-confi
   templateUrl: './chip.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [NgClass, TranslateModule],
+  host: { style: 'display: inline-block; vertical-align: middle' },
 })
 export class ItChipComponent {
   /**


### PR DESCRIPTION
## Summary

Fixes the decentered chip label when `<it-chip>` is placed inside a flex parent like `<it-list-item>`.

### Problem (#579)
Bootstrap Italia's `.chip` uses asymmetric padding (`0 4px 2px 8px`) and `transform: translateY(-2px)` on the label, calibrated for standalone usage. When nested inside a flex container (`<it-list-item>`), these properties interact with the parent's `align-items: center`, causing the label to appear visually off-center.

### Fix
Adds `host: { style: 'display: inline-block; vertical-align: middle' }` to `ItChipComponent`, which:
1. Isolates the chip's internal flex layout from parent flex contexts
2. Ensures proper vertical alignment with adjacent text via `vertical-align: middle`

### Testing
- Added regression test verifying host `display: inline-block` and `vertical-align: middle`
- All 110 unit tests pass
- 0 lint errors

Fixes #579

> ⚠️ This reopens #623 which was accidentally closed due to fork deletion.