### PR TITLE
fix(icon): inherit parent text color when no color input is set

### DIFF
--- a/projects/design-angular-kit/src/lib/components/utils/icon/icon.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/utils/icon/icon.component.spec.ts
@@ -1,3 +1,4 @@
+import { ChangeDetectionStrategy } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ItIconComponent } from './icon.component';
@@ -8,14 +9,46 @@ describe('ItIconComponent', () => {
   let fixture: ComponentFixture<ItIconComponent>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule(tb_base).compileComponents();
+    await TestBed.configureTestingModule({
+      imports: [ItIconComponent],
+      providers: tb_base.providers,
+    })
+      .overrideComponent(ItIconComponent, {
+        set: { changeDetection: ChangeDetectionStrategy.Default },
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(ItIconComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    component.name = 'burger';
+    fixture.detectChanges();
     expect(component).toBeTruthy();
+  });
+
+  it('should add icon-current-color class when no color input is provided (#607)', () => {
+    component.name = 'burger';
+    fixture.detectChanges();
+    const svg = fixture.nativeElement.querySelector('svg') as SVGElement;
+    expect(svg.getAttribute('class')).toContain('icon-current-color');
+  });
+
+  it('should NOT add icon-current-color class when a color input is provided (#607)', () => {
+    component.name = 'burger';
+    component.color = 'white';
+    fixture.detectChanges();
+    const svg = fixture.nativeElement.querySelector('svg') as SVGElement;
+    expect(svg.getAttribute('class')).not.toContain('icon-current-color');
+    expect(svg.getAttribute('class')).toContain('icon-white');
+  });
+
+  it('should apply icon-{color} class when color is set', () => {
+    component.name = 'burger';
+    component.color = 'primary';
+    fixture.detectChanges();
+    const svg = fixture.nativeElement.querySelector('svg') as SVGElement;
+    expect(svg.getAttribute('class')).toContain('icon-primary');
   });
 });

--- a/projects/design-angular-kit/src/lib/components/utils/icon/icon.component.ts
+++ b/projects/design-angular-kit/src/lib/components/utils/icon/icon.component.ts
@@ -6,7 +6,7 @@ import { IT_ASSET_BASE_PATH } from '../../../interfaces/design-angular-kit-confi
 @Component({
   selector: 'it-icon',
   templateUrl: './icon.component.html',
-  styles: ':host {display: contents;}',
+  styles: ':host {display: contents;} .icon-current-color { fill: currentColor; }',
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [],
 })
@@ -64,6 +64,8 @@ export class ItIconComponent {
     }
     if (this.color) {
       iconClass += ` icon-${this.color}`;
+    } else {
+      iconClass += ' icon-current-color';
     }
     if (this.padded) {
       iconClass += ` icon-padded`;


### PR DESCRIPTION
## What

Fixes #607 — Icons now inherit the parent element's text color when no explicit `color` input is set.

## Why

Bootstrap Italia's `.icon` class sets a hardcoded `fill: hsl(210,33%,28%)` (dark blue). When icons are placed inside elements with a different text color (e.g. `text-white`, `text-primary`), they ignore the parent color and remain dark blue. This breaks the expected CSS color inheritance.

## How

- Added an `icon-current-color` CSS class (scoped to the component) that sets `fill: currentColor`
- The `iconClass` getter now adds `icon-current-color` when no `color` input is provided
- When an explicit `color` input is set (e.g. `color="white"`), the standard `icon-{color}` class is applied instead — no override conflict
- This is a **non-breaking** change: existing usages that set `color` keep their current behavior; only the default (no color) case changes

## Tests

- 112/112 tests pass (0 lint errors)
- New regression tests verify:
  - `icon-current-color` class is present when no color input is set
  - `icon-current-color` class is absent when a color is set
  - `icon-{color}` class is correctly applied

## Migration

None required. Existing templates that use `<it-icon color="...">` are unaffected.
Icons that previously showed hardcoded dark blue will now inherit the parent's text color, which is the expected behavior.

> ⚠️ This reopens #624 which was accidentally closed due to fork deletion.