### PR TITLE
fix(abstract-form): delegate hasError/getError to NgControl.control

### DIFF
--- a/projects/design-angular-kit/src/lib/abstracts/abstract-form.component.ts
+++ b/projects/design-angular-kit/src/lib/abstracts/abstract-form.component.ts
@@ -183,8 +183,8 @@ export abstract class ItAbstractFormComponent<T = any> extends ItAbstractCompone
    * @returns whether the given error is present in the control at the given path.
    */
   public hasError(errorCode: string, path?: Array<string | number> | string): boolean {
-    if (this._ngControl) {
-      return this._ngControl.hasError(errorCode, path);
+    if (this._ngControl?.control) {
+      return this._ngControl.control.hasError(errorCode, path);
     }
     return this.control.hasError(errorCode, path);
   }
@@ -198,8 +198,8 @@ export abstract class ItAbstractFormComponent<T = any> extends ItAbstractCompone
    * null is returned.
    */
   public getError(errorCode: string, path?: Array<string | number> | string): any {
-    if (this._ngControl) {
-      return this._ngControl.getError(errorCode, path);
+    if (this._ngControl?.control) {
+      return this._ngControl.control.getError(errorCode, path);
     }
     return this.control.getError(errorCode, path);
   }

--- a/projects/design-angular-kit/src/lib/components/form/input/input.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/form/input/input.component.spec.ts
@@ -1,4 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 
 import { ItInputComponent } from './input.component';
 import { tb_base } from '../../../../test';
@@ -17,5 +19,89 @@ describe('ItInputComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+@Component({
+  template: `
+    <form [formGroup]="form">
+      <it-input formControlName="email" label="Email" [validationMode]="true"></it-input>
+    </form>
+  `,
+  imports: [ReactiveFormsModule, ItInputComponent],
+})
+class TestHostComponent {
+  form = new FormGroup({
+    email: new FormControl('', [Validators.required, Validators.email]),
+  });
+}
+
+describe('ItInputComponent — Signal Forms compatibility (#572)', () => {
+  let host: TestHostComponent;
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      ...tb_base,
+      imports: [...tb_base.imports, TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should not throw when calling hasError via NgControl', () => {
+    const control = host.form.get('email')!;
+    control.markAsTouched();
+    control.setValue('');
+    expect(() => fixture.detectChanges()).not.toThrow();
+  });
+
+  it('should correctly report required error via hasError', () => {
+    const control = host.form.get('email')!;
+    control.markAsTouched();
+    control.setValue('');
+    fixture.detectChanges();
+
+    const inputEl = fixture.debugElement.children[0].children[0];
+    const inputComp = inputEl.componentInstance as ItInputComponent;
+    expect(inputComp.hasError('required')).toBeTrue();
+  });
+
+  it('should correctly report email error via hasError', () => {
+    const control = host.form.get('email')!;
+    control.markAsTouched();
+    control.setValue('not-an-email');
+    fixture.detectChanges();
+
+    const inputEl = fixture.debugElement.children[0].children[0];
+    const inputComp = inputEl.componentInstance as ItInputComponent;
+    expect(inputComp.hasError('email')).toBeTrue();
+    expect(inputComp.hasError('required')).toBeFalse();
+  });
+
+  it('should return error details via getError', () => {
+    const control = host.form.get('email')!;
+    control.markAsTouched();
+    control.setValue('ab');
+    fixture.detectChanges();
+
+    const inputEl = fixture.debugElement.children[0].children[0];
+    const inputComp = inputEl.componentInstance as ItInputComponent;
+    const emailErr = inputComp.getError('email');
+    expect(emailErr).toBeTruthy();
+  });
+
+  it('should report no errors when value is valid', () => {
+    const control = host.form.get('email')!;
+    control.markAsTouched();
+    control.setValue('user@example.com');
+    fixture.detectChanges();
+
+    const inputEl = fixture.debugElement.children[0].children[0];
+    const inputComp = inputEl.componentInstance as ItInputComponent;
+    expect(inputComp.hasError('required')).toBeFalse();
+    expect(inputComp.hasError('email')).toBeFalse();
   });
 });


### PR DESCRIPTION
## What

Fixes #572 — `hasError is not a function` error when using Angular 21 Signal Forms.

## Why

In Angular 21 Signal Forms, `NgControl` no longer exposes `hasError()` and `getError()` directly. The methods exist on the underlying `AbstractControl`, accessible via `_ngControl.control`.

## How

Changed 2 lines in `abstract-form.component.ts`:
- `this._ngControl.hasError()` → `this._ngControl.control.hasError()`
- `this._ngControl.getError()` → `this._ngControl.control.getError()`

This follows the same pattern already used elsewhere in the same file (lines 91, 136-152, 171-173).

## Tests

- 114/114 tests pass (0 lint errors)
- 5 new regression tests verify `hasError`/`getError` via `NgControl` in a Reactive Form context:
  - No throws when calling hasError
  - Required error correctly detected
  - Email error correctly detected
  - Error details returned via getError
  - No errors reported for valid input

## Migration

None. Public API unchanged — same signatures, same return types.

> ⚠️ This reopens #626 which was accidentally closed due to fork deletion.