### PR TITLE
fix(forms): show validation errors only on blur, not while typing

### DIFF
--- a/projects/design-angular-kit/src/lib/abstracts/abstract-form.component.ts
+++ b/projects/design-angular-kit/src/lib/abstracts/abstract-form.component.ts
@@ -57,9 +57,9 @@ export abstract class ItAbstractFormComponent<T = any> extends ItAbstractCompone
     }
 
     if (this._ngControl) {
-      return this._ngControl.invalid === true && (!this._ngControl.pristine || this._ngControl.touched === true);
+      return this._ngControl.invalid === true && this._ngControl.touched === true;
     }
-    return this.control.invalid && (!this.control.pristine || this.control.touched);
+    return this.control.invalid && this.control.touched;
   }
 
   /**
@@ -71,9 +71,9 @@ export abstract class ItAbstractFormComponent<T = any> extends ItAbstractCompone
     }
 
     if (this._ngControl) {
-      return this._ngControl.valid === true && (!this._ngControl.pristine || this._ngControl.touched === true);
+      return this._ngControl.valid === true && this._ngControl.touched === true;
     }
-    return this.control.valid && (!this.control.pristine || this.control.touched);
+    return this.control.valid && this.control.touched;
   }
 
   /**

--- a/projects/design-angular-kit/src/lib/components/form/input/input.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/form/input/input.component.spec.ts
@@ -1,7 +1,25 @@
+import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 
 import { ItInputComponent } from './input.component';
 import { tb_base } from '../../../../test';
+
+@Component({
+  selector: 'it-input-validation-host',
+  standalone: true,
+  imports: [ReactiveFormsModule, ItInputComponent],
+  template: `
+    <form [formGroup]="form">
+      <it-input formControlName="name" label="Name" validationMode="only-invalid"></it-input>
+    </form>
+  `,
+})
+class ItInputValidationHostComponent {
+  form = new FormGroup({
+    name: new FormControl('', [Validators.required, Validators.minLength(3)]),
+  });
+}
 
 describe('ItInputComponent', () => {
   let component: ItInputComponent;
@@ -17,5 +35,89 @@ describe('ItInputComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+describe('ItInputComponent — onBlur validation (#588)', () => {
+  let fixture: ComponentFixture<ItInputValidationHostComponent>;
+  let hostComponent: ItInputValidationHostComponent;
+
+  beforeEach(async () => {
+    const config = { ...tb_base, imports: [...(tb_base.imports || []), ItInputValidationHostComponent] };
+    await TestBed.configureTestingModule(config).compileComponents();
+
+    fixture = TestBed.createComponent(ItInputValidationHostComponent);
+    hostComponent = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should NOT show validation error while user is typing (dirty but not touched)', () => {
+    const nameCtrl = hostComponent.form.controls.name;
+
+    // Simulate typing (makes control dirty but NOT touched)
+    nameCtrl.setValue('ab');
+    nameCtrl.markAsDirty();
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const errorDiv = el.querySelector('.form-feedback.just-validate-error-label');
+    const invalidInput = el.querySelector('.is-invalid');
+
+    expect(nameCtrl.invalid).toBeTrue();
+    expect(nameCtrl.dirty).toBeTrue();
+    expect(nameCtrl.touched).toBeFalse();
+    expect(errorDiv).toBeNull();
+    expect(invalidInput).toBeNull();
+  });
+
+  it('should show validation error ONLY after blur (touched)', () => {
+    const nameCtrl = hostComponent.form.controls.name;
+
+    // Simulate typing + blur
+    nameCtrl.setValue('ab');
+    nameCtrl.markAsDirty();
+    nameCtrl.markAsTouched();
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const errorDiv = el.querySelector('.form-feedback.just-validate-error-label');
+    const invalidInput = el.querySelector('.is-invalid');
+
+    expect(nameCtrl.invalid).toBeTrue();
+    expect(nameCtrl.touched).toBeTrue();
+    expect(errorDiv).toBeTruthy();
+    expect(invalidInput).toBeTruthy();
+  });
+
+  it('should NOT show error for a valid field even after blur', () => {
+    const nameCtrl = hostComponent.form.controls.name;
+
+    nameCtrl.setValue('Valid Name');
+    nameCtrl.markAsDirty();
+    nameCtrl.markAsTouched();
+    fixture.detectChanges();
+
+    const el: HTMLElement = fixture.nativeElement;
+    const errorDiv = el.querySelector('.form-feedback.just-validate-error-label');
+    const invalidInput = el.querySelector('.is-invalid');
+
+    expect(nameCtrl.valid).toBeTrue();
+    expect(errorDiv).toBeNull();
+    expect(invalidInput).toBeNull();
+  });
+
+  it('should clear validation error when user corrects the value', () => {
+    const nameCtrl = hostComponent.form.controls.name;
+
+    // First: invalid + touched → error shown
+    nameCtrl.setValue('ab');
+    nameCtrl.markAsTouched();
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.is-invalid')).toBeTruthy();
+
+    // Then: user corrects → error cleared
+    nameCtrl.setValue('Valid Name');
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.is-invalid')).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

Form validation messages appear **while the user is still typing**, which is disruptive and poor UX. Error messages should only show after the user has finished editing a field (on blur).

**Root cause**: The `isInvalid`/`isValid` getters in `AbstractFormComponent` use:
```
```
This evaluates to `true` as soon as the control becomes **dirty** (user starts typing), even before the field loses focus.

## Solution

Change the condition to require **only** the `touched` state:
```typescript
// Before: shows during typing (dirty triggers it)

// After: shows only on blur  
invalid && touched
```

Since the template already binds `(blur)="markAsTouched()"`, validation now correctly appears only after blur.

## Testing

Added 4 strict tests in `input.component.spec.ts`:
- ✅ **NOT show** validation error while typing (dirty but not touched)
- ✅ **Show** validation error only after blur (touched)
- ✅ **NOT show** error for valid fields even after blur
- ✅ **Clear** error when user corrects the value

Full test suite: **113/113 SUCCESS**

Closes #588

> ⚠️ This reopens #632 which was accidentally closed due to fork deletion.