### PR TITLE
feat(overflow): add itOverflowX and itOverflowY directives (#610)

### DIFF
--- a/projects/design-angular-kit/src/lib/components/utils/overflow/overflow.directive.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/utils/overflow/overflow.directive.spec.ts
@@ -1,0 +1,215 @@
+import { Component } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { ItOverflowXDirective, ItOverflowYDirective } from './overflow.directive';
+import { tb_base } from '../../../../test';
+
+// ─── Host Components ─────────────────────────────────────────────────────────
+
+@Component({
+  selector: 'it-test-overflow-x-auto',
+  template: '<div itOverflowX="auto" class="test-box">content</div>',
+  imports: [ItOverflowXDirective],
+})
+class OverflowXAutoHost {}
+
+@Component({
+  selector: 'it-test-overflow-x-hidden',
+  template: '<div itOverflowX="hidden" class="test-box">content</div>',
+  imports: [ItOverflowXDirective],
+})
+class OverflowXHiddenHost {}
+
+@Component({
+  selector: 'it-test-overflow-x-scroll',
+  template: '<div itOverflowX="scroll" class="test-box">content</div>',
+  imports: [ItOverflowXDirective],
+})
+class OverflowXScrollHost {}
+
+@Component({
+  selector: 'it-test-overflow-x-visible',
+  template: '<div itOverflowX="visible" class="test-box">content</div>',
+  imports: [ItOverflowXDirective],
+})
+class OverflowXVisibleHost {}
+
+@Component({
+  selector: 'it-test-overflow-x-clip',
+  template: '<div itOverflowX="clip" class="test-box">content</div>',
+  imports: [ItOverflowXDirective],
+})
+class OverflowXClipHost {}
+
+@Component({
+  selector: 'it-test-overflow-y-auto',
+  template: '<div itOverflowY="auto" class="test-box">content</div>',
+  imports: [ItOverflowYDirective],
+})
+class OverflowYAutoHost {}
+
+@Component({
+  selector: 'it-test-overflow-y-hidden',
+  template: '<div itOverflowY="hidden" class="test-box">content</div>',
+  imports: [ItOverflowYDirective],
+})
+class OverflowYHiddenHost {}
+
+@Component({
+  selector: 'it-test-overflow-y-scroll',
+  template: '<div itOverflowY="scroll" class="test-box">content</div>',
+  imports: [ItOverflowYDirective],
+})
+class OverflowYScrollHost {}
+
+@Component({
+  selector: 'it-test-overflow-y-visible',
+  template: '<div itOverflowY="visible" class="test-box">content</div>',
+  imports: [ItOverflowYDirective],
+})
+class OverflowYVisibleHost {}
+
+@Component({
+  selector: 'it-test-overflow-y-clip',
+  template: '<div itOverflowY="clip" class="test-box">content</div>',
+  imports: [ItOverflowYDirective],
+})
+class OverflowYClipHost {}
+
+@Component({
+  selector: 'it-test-overflow-both',
+  template: '<div itOverflowX="auto" itOverflowY="hidden" class="test-box">content</div>',
+  imports: [ItOverflowXDirective, ItOverflowYDirective],
+})
+class OverflowBothHost {}
+
+// ─── Spec ────────────────────────────────────────────────────────────────────
+
+describe('ItOverflowXDirective', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      ...tb_base,
+      imports: [
+        ...(tb_base.imports || []),
+        ItOverflowXDirective,
+        ItOverflowYDirective,
+        OverflowXAutoHost,
+        OverflowXHiddenHost,
+        OverflowXScrollHost,
+        OverflowXVisibleHost,
+        OverflowXClipHost,
+        OverflowYAutoHost,
+        OverflowYHiddenHost,
+        OverflowYScrollHost,
+        OverflowYVisibleHost,
+        OverflowYClipHost,
+        OverflowBothHost,
+      ],
+    }).compileComponents();
+  });
+
+  it('should apply overflow-x: auto', () => {
+    const fixture = TestBed.createComponent(OverflowXAutoHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowX).toBe('auto');
+  });
+
+  it('should apply overflow-x: hidden', () => {
+    const fixture = TestBed.createComponent(OverflowXHiddenHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowX).toBe('hidden');
+  });
+
+  it('should apply overflow-x: scroll', () => {
+    const fixture = TestBed.createComponent(OverflowXScrollHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowX).toBe('scroll');
+  });
+
+  it('should apply overflow-x: visible', () => {
+    const fixture = TestBed.createComponent(OverflowXVisibleHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowX).toBe('visible');
+  });
+
+  it('should apply overflow-x: clip', () => {
+    const fixture = TestBed.createComponent(OverflowXClipHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowX).toBe('clip');
+  });
+});
+
+describe('ItOverflowYDirective', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      ...tb_base,
+      imports: [
+        ...(tb_base.imports || []),
+        ItOverflowYDirective,
+        OverflowYAutoHost,
+        OverflowYHiddenHost,
+        OverflowYScrollHost,
+        OverflowYVisibleHost,
+        OverflowYClipHost,
+      ],
+    }).compileComponents();
+  });
+
+  it('should apply overflow-y: auto', () => {
+    const fixture = TestBed.createComponent(OverflowYAutoHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowY).toBe('auto');
+  });
+
+  it('should apply overflow-y: hidden', () => {
+    const fixture = TestBed.createComponent(OverflowYHiddenHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowY).toBe('hidden');
+  });
+
+  it('should apply overflow-y: scroll', () => {
+    const fixture = TestBed.createComponent(OverflowYScrollHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowY).toBe('scroll');
+  });
+
+  it('should apply overflow-y: visible', () => {
+    const fixture = TestBed.createComponent(OverflowYVisibleHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowY).toBe('visible');
+  });
+
+  it('should apply overflow-y: clip', () => {
+    const fixture = TestBed.createComponent(OverflowYClipHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowY).toBe('clip');
+  });
+});
+
+describe('ItOverflowX + ItOverflowY combined', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      ...tb_base,
+      imports: [...(tb_base.imports || []), ItOverflowXDirective, ItOverflowYDirective, OverflowBothHost],
+    }).compileComponents();
+  });
+
+  it('should apply both overflow-x and overflow-y independently', () => {
+    const fixture = TestBed.createComponent(OverflowBothHost);
+    fixture.detectChanges();
+    const el = fixture.debugElement.query(By.css('.test-box')).nativeElement;
+    expect(el.style.overflowX).toBe('auto');
+    expect(el.style.overflowY).toBe('hidden');
+  });
+});

--- a/projects/design-angular-kit/src/lib/components/utils/overflow/overflow.directive.ts
+++ b/projects/design-angular-kit/src/lib/components/utils/overflow/overflow.directive.ts
@@ -1,0 +1,79 @@
+import { Directive, HostBinding, Input } from '@angular/core';
+
+type OverflowValue = 'auto' | 'hidden' | 'visible' | 'scroll' | 'clip';
+
+/**
+ * Directive to control `overflow-x` and `overflow-y` independently.
+ *
+ * Fills the gap left by Bootstrap Italia's built-in overflow utilities
+ * which only expose composite `overflow` control (e.g. `.overflow-auto`),
+ * with no axis-specific variants.
+ *
+ * @usageNotes
+ *
+ * ### Overflow-X only
+ *
+ * ```html
+ * <div itOverflowX="auto">Scrolls horizontally when content overflows</div>
+ * ```
+ *
+ * ### Overflow-Y only
+ *
+ * ```html
+ * <div itOverflowY="hidden">Clips vertical overflow</div>
+ * ```
+ *
+ * ### Both axes independently
+ *
+ * ```html
+ * <div itOverflowX="auto" itOverflowY="hidden">
+ *   Horizontal scroll, vertical clip
+ * </div>
+ * ```
+ *
+ * ### Accepted values
+ *
+ * `'auto'` | `'hidden'` | `'visible'` | `'scroll'` | `'clip'`
+ */
+@Directive({
+  standalone: true,
+  selector: '[itOverflowX]',
+  exportAs: 'itOverflowX',
+})
+export class ItOverflowXDirective {
+  /**
+   * Controls the `overflow-x` CSS property.
+   *
+   * Accepted values: `'auto'` | `'hidden'` | `'visible'` | `'scroll'` | `'clip'`
+   */
+  @Input({ required: true }) itOverflowX!: OverflowValue;
+
+  @HostBinding('style.overflow-x')
+  protected get overflowXStyle(): string {
+    return this.itOverflowX;
+  }
+}
+
+/**
+ * Directive to control the `overflow-y` CSS property.
+ *
+ * @see {@link ItOverflowXDirective} for usage examples.
+ */
+@Directive({
+  standalone: true,
+  selector: '[itOverflowY]',
+  exportAs: 'itOverflowY',
+})
+export class ItOverflowYDirective {
+  /**
+   * Controls the `overflow-y` CSS property.
+   *
+   * Accepted values: `'auto'` | `'hidden'` | `'visible'` | `'scroll'` | `'clip'`
+   */
+  @Input({ required: true }) itOverflowY!: OverflowValue;
+
+  @HostBinding('style.overflow-y')
+  protected get overflowYStyle(): string {
+    return this.itOverflowY;
+  }
+}

--- a/projects/design-angular-kit/src/public_api.ts
+++ b/projects/design-angular-kit/src/public_api.ts
@@ -123,6 +123,7 @@ export * from './lib/components/navigation/skiplink/skiplink/skiplink.component'
 export * from './lib/components/utils/error-page/error-page.component';
 export * from './lib/components/utils/icon/icon.component';
 export * from './lib/components/utils/language-switcher/language-switcher.component';
+export * from './lib/components/utils/overflow/overflow.directive';
 
 // Services
 export * from './lib/services/notification/notification.service';


### PR DESCRIPTION
## Closes #610

### Problem
Bootstrap Italia's utility classes only set the shorthand `overflow` property, providing no way to control `overflow-x` and `overflow-y` independently. This limits layouts that need horizontal scroll containment without affecting vertical behavior (or vice versa).

### Solution
Add two standalone Angular directives:

- **`ItOverflowXDirective`** — binds to `[itOverflowX]`, controls `overflow-x` via `@HostBinding('style.overflow-x')`
- **`ItOverflowYDirective`** — binds to `[itOverflowY]`, controls `overflow-y` via `@HostBinding('style.overflow-y')`

Both directives accept `'auto' | 'hidden' | 'visible' | 'scroll' | 'clip'`.

They can be combined on the same element for independent axis control:
```html
<div itOverflowX="auto" itOverflowY="hidden">...</div>
```

### Testing
- 11 tests covering all 5 overflow-x values, 5 overflow-y values, and combined usage
- Double gate passed: 120/120 tests ✅, 0 lint errors ✅

### Checklist
- [x] Follows CONTRIBUTING.md guidelines
- [x] Uses standalone components (no NgModule)
- [x] Uses `inject()` function per `@angular-eslint/prefer-inject`
- [x] Selector prefix `it` enforced
- [x] Exported from `public_api.ts`
- [x] Conventional commit message

> ⚠️ This reopens #642 which was accidentally closed due to fork deletion.