### PR TITLE
fix(alert): hide empty h4.alert-heading when no heading content is projected (#547)

### DIFF
--- a/projects/design-angular-kit/src/lib/components/core/alert/alert.component.html
+++ b/projects/design-angular-kit/src/lib/components/core/alert/alert.component.html
@@ -5,7 +5,7 @@
   [class.fade]="dismissible"
   [class.show]="dismissible"
   role="alert">
-  <h4 class="alert-heading">
+  <h4 #headingEl class="alert-heading">
     <ng-content select="[heading]"></ng-content>
   </h4>
 

--- a/projects/design-angular-kit/src/lib/components/core/alert/alert.component.spec.ts
+++ b/projects/design-angular-kit/src/lib/components/core/alert/alert.component.spec.ts
@@ -29,6 +29,18 @@ class UnitTestComponent {
   private _dismissible: boolean = false;
 }
 
+@Component({
+  selector: 'it-heading-test',
+  template: `
+    <it-alert color="info">
+      <span heading>Attenzione</span>
+      Contenuto dell'alert.
+    </it-alert>
+  `,
+  imports: [ItAlertComponent],
+})
+class HeadingTestComponent {}
+
 let component: UnitTestComponent;
 let fixture: ComponentFixture<UnitTestComponent>;
 describe('ItAlertComponent', () => {
@@ -59,5 +71,42 @@ describe('ItAlertComponent', () => {
     fixture.detectChanges();
     const spanElement = fixture.debugElement.query(By.css('div.alert.alert-success'));
     expect(spanElement).toBeTruthy();
+  });
+
+  it('should hide empty h4.alert-heading when no heading content is projected', () => {
+    fixture.detectChanges();
+    const h4: HTMLHeadingElement = fixture.nativeElement.querySelector('h4.alert-heading');
+    expect(h4).toBeTruthy();
+    expect(h4.hidden).toBeTrue();
+  });
+
+  it('hidden h4 should not be visible in the DOM flow', () => {
+    fixture.detectChanges();
+    const h4: HTMLHeadingElement = fixture.nativeElement.querySelector('h4.alert-heading');
+    expect(h4.offsetHeight).toBe(0);
+  });
+});
+
+describe('ItAlertComponent with heading', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HeadingTestComponent, ItAlertComponent],
+    }).compileComponents();
+  });
+
+  it('should show h4.alert-heading when heading content is projected', () => {
+    const f = TestBed.createComponent(HeadingTestComponent);
+    f.detectChanges();
+    const h4: HTMLHeadingElement = f.nativeElement.querySelector('h4.alert-heading');
+    expect(h4).toBeTruthy();
+    expect(h4.hidden).toBeFalse();
+    expect(h4.textContent?.trim()).toBe('Attenzione');
+  });
+
+  it('should preserve alert-heading class when heading is present', () => {
+    const f = TestBed.createComponent(HeadingTestComponent);
+    f.detectChanges();
+    const h4: HTMLHeadingElement = f.nativeElement.querySelector('h4.alert-heading');
+    expect(h4.classList.contains('alert-heading')).toBeTrue();
   });
 });

--- a/projects/design-angular-kit/src/lib/components/core/alert/alert.component.ts
+++ b/projects/design-angular-kit/src/lib/components/core/alert/alert.component.ts
@@ -44,9 +44,18 @@ export class ItAlertComponent extends ItAbstractComponent implements AfterViewIn
   private alert?: Alert;
 
   @ViewChild('alertElement') private alertElement?: ElementRef<HTMLDivElement>;
+  @ViewChild('headingEl') private headingEl?: ElementRef<HTMLHeadingElement>;
 
   override ngAfterViewInit() {
     super.ngAfterViewInit();
+
+    // Hide empty heading to prevent accessibility issues (#547)
+    if (this.headingEl?.nativeElement) {
+      const el = this.headingEl.nativeElement;
+      if (el.textContent?.trim() === '') {
+        el.hidden = true;
+      }
+    }
 
     if (this.alertElement) {
       const element = this.alertElement.nativeElement;


### PR DESCRIPTION
## Summary

Fixes #547

The alert component always renders an empty `<h4 class="alert-heading">` element even when no `[heading]` content is projected. This impacts accessibility by adding a meaningless heading to the document outline.

## Changes

- Added `#headingEl` ViewChild reference to the h4 element
- In `ngAfterViewInit`, checks if the heading has empty text content and sets `hidden=true`
- When heading content IS projected, the h4 renders normally

## Testing

4 new tests:
1. Empty h4 is hidden when no heading projected
2. Hidden h4 has zero offset height (not in layout)
3. h4 is visible when heading content is projected
4. alert-heading class preserved when heading present

All 113 tests passing (double gate). 0 lint errors.

> ⚠️ This reopens #651 which was accidentally closed due to fork deletion.