### PR TITLE
feat(upload): add preview and remove actions for drag & drop upload

### DIFF
--- a/projects/design-angular-kit/assets/i18n/en.json
+++ b/projects/design-angular-kit/assets/i18n/en.json
@@ -85,6 +85,8 @@
       "upload-complete": "Upload completed",
       "upload-or": "or",
       "upload-select-device": "select it from the device",
+      "upload-view": "View",
+      "upload-clear": "Clear",
       "uploaded-file": "File uploaded: {{name}}",
       "delete-file": "Delete file {{name}}"
     },

--- a/projects/design-angular-kit/assets/i18n/it.json
+++ b/projects/design-angular-kit/assets/i18n/it.json
@@ -85,6 +85,8 @@
       "upload-complete": "Caricamento completato",
       "upload-or": "oppure",
       "upload-select-device": "selezionalo dal dispositivo",
+      "upload-view": "Visualizza",
+      "upload-clear": "Svuota",
       "uploaded-file": "File caricato: {{name}}",
       "delete-file": "Elimina file {{name}}"
     },

--- a/projects/design-angular-kit/src/lib/components/form/upload-drag-drop/upload-drag-drop.component.html
+++ b/projects/design-angular-kit/src/lib/components/form/upload-drag-drop/upload-drag-drop.component.html
@@ -24,6 +24,22 @@
     }
     @if (isSuccess) {
       <p>{{ 'it.form.upload-complete' | translate }}</p>
+      <div class="mt-3">
+        <button
+          type="button"
+          itButton="primary"
+          size="sm"
+          class="me-2"
+          [attr.aria-label]="'it.form.upload-view' | translate"
+          (click)="viewFile()">
+          <it-icon name="password-visible" size="sm"></it-icon>
+          {{ 'it.form.upload-view' | translate }}
+        </button>
+        <button type="button" itButton="outline-primary" size="sm" [attr.aria-label]="'it.form.upload-clear' | translate" (click)="reset()">
+          <it-icon name="close" size="sm"></it-icon>
+          {{ 'it.form.upload-clear' | translate }}
+        </button>
+      </div>
     }
     @if (!isLoading && !isSuccess) {
       <p>

--- a/projects/design-angular-kit/src/lib/components/form/upload-drag-drop/upload-drag-drop.component.ts
+++ b/projects/design-angular-kit/src/lib/components/form/upload-drag-drop/upload-drag-drop.component.ts
@@ -17,13 +17,14 @@ import { ItIconComponent } from '../../utils/icon/icon.component';
 import { NgOptimizedImage } from '@angular/common';
 import { TranslateModule } from '@ngx-translate/core';
 import { IT_ASSET_BASE_PATH } from '../../../interfaces/design-angular-kit-config';
+import { ItButtonDirective } from '../../core/button/button.directive';
 
 @Component({
   selector: 'it-upload-drag-drop',
   templateUrl: './upload-drag-drop.component.html',
   exportAs: 'itUploadDragDrop',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [ItIconComponent, TranslateModule, NgOptimizedImage],
+  imports: [ItIconComponent, TranslateModule, NgOptimizedImage, ItButtonDirective],
 })
 export class ItUploadDragDropComponent extends ItAbstractComponent implements AfterViewInit {
   /**
@@ -39,6 +40,11 @@ export class ItUploadDragDropComponent extends ItAbstractComponent implements Af
    */
   @Output() fileStartUpload = new EventEmitter<File>();
 
+  /**
+   * Fired when filed is removed
+   */
+  @Output() fileRemoved = new EventEmitter<void>();
+
   protected isDragover: boolean = false;
   protected isLoading: boolean = false;
   protected isSuccess: boolean = false;
@@ -50,6 +56,7 @@ export class ItUploadDragDropComponent extends ItAbstractComponent implements Af
   protected filename?: string;
   protected extension?: string;
   protected fileSize?: string;
+  protected uploadedFile?: File;
 
   /**
    * The bootstrap-italia asset folder path
@@ -127,6 +134,7 @@ export class ItUploadDragDropComponent extends ItAbstractComponent implements Af
     this.filename = splitName[0];
     this.extension = splitName[1]?.toUpperCase();
     this.fileSize = ItFileUtils.getFileSizeString(file);
+    this.uploadedFile = file;
 
     this.fileStartUpload.emit(file);
   }
@@ -157,13 +165,26 @@ export class ItUploadDragDropComponent extends ItAbstractComponent implements Af
   }
 
   /**
+   * View the uploaded file in a new browser tab
+   */
+  public viewFile(): void {
+    if (!this.uploadedFile) {
+      return;
+    }
+    const fileURL = URL.createObjectURL(this.uploadedFile);
+    window.open(fileURL, '_blank');
+  }
+
+  /**
    * Reset file uploader
    */
   public reset(): void {
     this.isLoading = false;
     this.isSuccess = false;
-    this.filename = this.extension = this.fileSize = undefined;
+    this.filename = this.extension = this.fileSize = this.uploadedFile = undefined;
     this.donut?.set(0);
     this._changeDetectorRef.detectChanges();
+
+    this.fileRemoved.emit();
   }
 }


### PR DESCRIPTION
### Description

This PR introduces **preview** and **remove** actions for files uploaded through the drag & **drop upload component**.

Specifically:

added a button to preview the uploaded file
added a button to remove the selected file
improved the overall user experience when managing uploaded files

The implementation aligns with the expected behavior described in the related issue.

Fixes #732

### Checklist

- [X] Changes are compliant with the design guidelines
- [X] Code follows the project conventions
- [ ] Changes have been tested on supported browsers
- [ ] Accessibility tests have been performed
- [ ] Documentation has been updated

<img width="557" height="235" alt="Screenshot_29-6-2026_175026_127 0 0 1" src="https://github.com/user-attachments/assets/b2a7ca62-8863-4016-b7b6-a344954d35ef" />
